### PR TITLE
Add autonomous coding agent with local LLM support

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 This repository contains multiple microservices designed to handle Binance data collection, storage, and trading activities. The services communicate through Kafka, ensuring decoupled and efficient communication between them. The system also includes a Python-based Telegram bot for interaction.
 
+> **New:** The `autonomous-agent/` directory hosts a fully local autonomous coding assistant that can be launched together with a local LLM via Docker Compose. See [`autonomous-agent/README.md`](autonomous-agent/README.md) for setup instructions.
+
 ## Architecture Overview
 
 The system is split into several microservices, each responsible for specific tasks:

--- a/autonomous-agent/Dockerfile
+++ b/autonomous-agent/Dockerfile
@@ -1,0 +1,11 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+COPY pyproject.toml README.md config.sample.toml /app/
+COPY autonomous_agent /app/autonomous_agent
+RUN pip install --no-cache-dir --upgrade pip \
+    && pip install --no-cache-dir .
+
+ENV AGENT_CONFIG=/workspace/config.toml
+WORKDIR /workspace
+CMD ["autonomous-agent", "--task", "Describe the repository"]

--- a/autonomous-agent/MANIFEST.in
+++ b/autonomous-agent/MANIFEST.in
@@ -1,0 +1,2 @@
+recursive-include autonomous_agent *.txt *.md *.py
+include config.sample.toml

--- a/autonomous-agent/README.md
+++ b/autonomous-agent/README.md
@@ -1,0 +1,98 @@
+# Autonomous Coding Agent
+
+This package provides a lightweight autonomous coding agent that mimics key Cursor-like features while staying entirely local. The agent is designed to:
+
+- run a local LLM for reasoning and tool orchestration;
+- plan tasks automatically and work towards goals in an iterative manner;
+- interact with the filesystem to inspect, create and modify code files;
+- communicate with Model Context Protocol (MCP) servers to extend its toolset;
+- be launched from the command line or through Docker Compose together with the local LLM runtime.
+
+## Features
+
+- **Planning-first workflow** – every task is decomposed into actionable steps before execution.
+- **Tool-aware reasoning** – the agent keeps a catalog of tools (filesystem, search, patch) and reasons about which tool to execute next.
+- **MCP integration** – the agent can connect to one or more MCP servers that expose extra tools over JSON-RPC.
+- **Configurable runtime** – behaviour is defined via a `config.toml` file or environment variables.
+- **Docker-first setup** – a Dockerfile and `docker-compose.agent.yml` help spin up both the LLM runtime (`ollama`) and the agent service.
+
+## Quick start
+
+1. **Prepare configuration**
+
+   Copy the sample configuration and adjust paths or models as needed:
+
+   ```bash
+   cp config.sample.toml config.toml
+   ```
+
+2. **Start with Docker Compose**
+
+   ```bash
+   docker compose -f docker-compose.agent.yml up --build
+   ```
+
+   The compose file launches two services:
+
+   - `llm`: an [`ollama`](https://github.com/ollama/ollama) instance serving OpenAI compatible endpoints;
+   - `agent`: the autonomous agent container which mounts your workspace and talks to the LLM.
+
+3. **Run from the host**
+
+   ```bash
+   poetry run autonomous-agent --task "Add unit tests for the config loader"
+   ```
+
+   or, without Poetry:
+
+   ```bash
+   python -m autonomous_agent.cli --task "Describe repository"
+   ```
+
+## Configuration
+
+Create a `config.toml` (or rely on `config.sample.toml`). Key sections:
+
+```toml
+[llm]
+base_url = "http://llm:11434/v1"
+model = "llama3.1:8b-instruct"
+request_timeout = 120
+
+[agent]
+workspace = "."
+auto_plan = true
+max_iterations = 12
+
+[mcp]
+enabled = true
+servers = [
+  { name = "filesystem", command = "python", args = ["-m", "autonomous_agent.mcp.servers.filesystem"], cwd = "." }
+]
+```
+
+Environment variables such as `AGENT_MODEL`, `AGENT_BASE_URL`, `AGENT_WORKSPACE` override config values.
+
+## MCP support
+
+The Model Context Protocol allows the agent to discover external tools. Each server is started as a subprocess using the provided command. The agent initialises servers using JSON-RPC (`initialize`, `listTools`) and exposes them as built-in tools.
+
+A tiny reference server is included (`autonomous_agent.mcp.servers.filesystem`) which grants read-only access to files under the workspace root. You can add your own servers by implementing the JSON-RPC contract described in `autonomous_agent/mcp/README.md`.
+
+## Development
+
+- `tests/` contains a minimal unit-test suite that exercises the config loader, planner and agent loop via stubbed LLM responses.
+- Run tests with:
+
+  ```bash
+  python -m pytest
+  ```
+
+- Formatting follows the default `black` style (120 char width) although no formatter is bundled.
+
+## Roadmap
+
+- Add real diff-based editing tools (currently the agent overwrites files when writing).
+- Support multi-agent collaboration through MCP.
+- Integrate vector search for repository-scale recall.
+

--- a/autonomous-agent/autonomous_agent/__init__.py
+++ b/autonomous-agent/autonomous_agent/__init__.py
@@ -1,0 +1,12 @@
+"""Autonomous agent package."""
+
+from .agent import AutonomousCoderAgent
+from .config import AgentConfig, LLMConfig, MCPConfig, load_config
+
+__all__ = [
+    "AutonomousCoderAgent",
+    "AgentConfig",
+    "LLMConfig",
+    "MCPConfig",
+    "load_config",
+]

--- a/autonomous-agent/autonomous_agent/agent.py
+++ b/autonomous-agent/autonomous_agent/agent.py
@@ -1,0 +1,149 @@
+"""Core autonomous coding agent."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, List, Optional
+
+from .config import RuntimeConfig
+from .llm_client import ChatMessage, LLMClient
+from .mcp import MCPManager
+from .planner import Plan, Planner
+from .tools import ToolError, ToolRegistry, create_default_registry
+from .utils import extract_json_blob
+
+
+@dataclass(slots=True)
+class AgentResult:
+    task: str
+    final_response: str
+    plan: Optional[Plan]
+    iterations: int
+    tool_calls: List[Dict[str, str]]
+
+
+class AutonomousCoderAgent:
+    def __init__(
+        self,
+        runtime: RuntimeConfig,
+        llm: Optional[LLMClient] = None,
+        planner: Optional[Planner] = None,
+        tool_registry: Optional[ToolRegistry] = None,
+        system_prompt_path: Optional[Path] = None,
+    ):
+        self._runtime = runtime
+        self._workspace = runtime.agent.resolve_workspace()
+        self._llm = llm or LLMClient(runtime.llm)
+        prompt_file = system_prompt_path or Path(__file__).parent / 'prompts' / 'system_agent.txt'
+        self._system_prompt = Path(prompt_file).read_text(encoding='utf-8')
+        planner_prompt = Path(__file__).parent / 'prompts' / 'system_planner.txt'
+        self._planner = planner or Planner(self._llm, planner_prompt)
+        self._tools = tool_registry or create_default_registry(self._workspace)
+        self._mcp = MCPManager(runtime.mcp, self._tools)
+        self._history: List[ChatMessage] = []
+
+    @property
+    def tools(self) -> ToolRegistry:
+        return self._tools
+
+    @property
+    def llm(self) -> LLMClient:
+        return self._llm
+
+    def run(self, task: str) -> AgentResult:
+        self._mcp.start()
+        plan: Optional[Plan] = None
+        if self._runtime.agent.auto_plan:
+            plan = self._planner.make_plan(task, self._tools.names())
+
+        plan_summary = plan.summary() if plan else 'Planning disabled.'
+        tools_description = '\n'.join(
+            f"- {tool['name']}: {tool['description']} | params: {tool['parameters']}"
+            for tool in self._tools.describe()
+        )
+        system_prompt = (
+            self._system_prompt
+            + '\nAvailable tools:\n'
+            + tools_description
+            + '\nCurrent plan:\n'
+            + plan_summary
+        )
+        self._history = [ChatMessage(role='system', content=system_prompt)]
+        self._history.append(ChatMessage(role='user', content=f'Task: {task}'))
+
+        iterations = 0
+        tool_calls: List[Dict[str, str]] = []
+        try:
+            while iterations < self._runtime.agent.max_iterations:
+                iterations += 1
+                response = self._llm.chat(self._history, temperature=0.2)
+                assistant_text = response.content
+                self._history.append(ChatMessage(role='assistant', content=assistant_text))
+                try:
+                    data = extract_json_blob(assistant_text)
+                except Exception as exc:  # pragma: no cover - depends on LLM
+                    self._history.append(
+                        ChatMessage(
+                            role='user',
+                            content=f'Invalid JSON detected: {exc}. Please respond with valid JSON per instructions.',
+                        )
+                    )
+                    continue
+
+                if isinstance(data, dict) and 'final' in data:
+                    final_response = str(data.get('final'))
+                    return AgentResult(
+                        task=task,
+                        final_response=final_response,
+                        plan=plan,
+                        iterations=iterations,
+                        tool_calls=tool_calls,
+                    )
+
+                if isinstance(data, dict) and 'action' in data:
+                    action = data['action'] or {}
+                    tool_name = action.get('tool')
+                    tool_input = action.get('input') or {}
+                    if not tool_name:
+                        self._history.append(
+                            ChatMessage(
+                                role='user',
+                                content='Tool name missing in action. Provide a valid tool call.',
+                            )
+                        )
+                        continue
+                    try:
+                        result = self._tools.execute(tool_name, **tool_input)
+                        tool_calls.append({'tool': tool_name, 'input': str(tool_input), 'output': result})
+                        self._history.append(ChatMessage(role='tool', content=f'{tool_name}: {result}'))
+                    except ToolError as exc:
+                        tool_calls.append({'tool': tool_name, 'input': str(tool_input), 'output': f'ERROR: {exc}'})
+                        self._history.append(ChatMessage(role='tool', content=f'{tool_name}: ERROR: {exc}'))
+                        self._history.append(
+                            ChatMessage(
+                                role='user',
+                                content='The previous tool call failed. Adjust your plan and try a different approach.',
+                            )
+                        )
+                    continue
+
+                self._history.append(
+                    ChatMessage(
+                        role='user',
+                        content='Your response must include either an action or a final answer. Please try again.',
+                    )
+                )
+
+            return AgentResult(
+                task=task,
+                final_response='Max iterations reached without final answer.',
+                plan=plan,
+                iterations=iterations,
+                tool_calls=tool_calls,
+            )
+        finally:
+            self._mcp.shutdown()
+
+
+__all__ = ['AutonomousCoderAgent', 'AgentResult']

--- a/autonomous-agent/autonomous_agent/cli.py
+++ b/autonomous-agent/autonomous_agent/cli.py
@@ -1,0 +1,61 @@
+"""Command line interface for the autonomous agent."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Optional
+
+from .agent import AutonomousCoderAgent
+from .config import load_config
+from .planner import Planner
+
+
+def parse_args(argv: Optional[list[str]] = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description='Autonomous coding agent CLI')
+    parser.add_argument('--config', type=Path, help='Path to config.toml')
+    parser.add_argument('--task', required=True, help='Task for the agent to solve')
+    parser.add_argument('--plan-only', action='store_true', help='Only generate a plan')
+    parser.add_argument('--json', action='store_true', help='Emit JSON output')
+    return parser.parse_args(argv)
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    args = parse_args(argv)
+    runtime = load_config(args.config)
+    agent = AutonomousCoderAgent(runtime)
+
+    if args.plan_only:
+        planner = Planner(agent.llm, Path(__file__).parent / 'prompts' / 'system_planner.txt')
+        plan = planner.make_plan(args.task, agent.tools.names())
+        if args.json:
+            print(json.dumps({'task': args.task, 'plan': [step.description for step in plan.steps]}, ensure_ascii=False))
+        else:
+            print(plan.summary())
+        return 0
+
+    result = agent.run(args.task)
+    if args.json:
+        print(
+            json.dumps(
+                {
+                    'task': result.task,
+                    'final': result.final_response,
+                    'plan': [step.description for step in (result.plan.steps if result.plan else [])],
+                    'iterations': result.iterations,
+                    'tool_calls': result.tool_calls,
+                },
+                ensure_ascii=False,
+            )
+        )
+    else:
+        if result.plan:
+            print(result.plan.summary())
+            print('-' * 40)
+        print(result.final_response)
+    return 0
+
+
+if __name__ == '__main__':  # pragma: no cover - CLI entry point
+    raise SystemExit(main())

--- a/autonomous-agent/autonomous_agent/config.py
+++ b/autonomous-agent/autonomous_agent/config.py
@@ -1,0 +1,169 @@
+"""Configuration handling for the autonomous agent."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Optional
+import os
+import tomllib
+
+
+@dataclass(slots=True)
+class LLMConfig:
+    base_url: str = "http://localhost:11434/v1"
+    model: str = "llama3"
+    request_timeout: int = 120
+    api_key: Optional[str] = None
+
+
+@dataclass(slots=True)
+class AgentConfig:
+    workspace: Path = Path('.')
+    auto_plan: bool = True
+    max_iterations: int = 12
+    reflection: bool = True
+
+    def resolve_workspace(self) -> Path:
+        path = self.workspace.expanduser().resolve()
+        path.mkdir(parents=True, exist_ok=True)
+        return path
+
+
+@dataclass(slots=True)
+class MCPServerConfig:
+    name: str
+    command: str
+    args: List[str] = field(default_factory=list)
+    cwd: Optional[Path] = None
+    env: Dict[str, str] = field(default_factory=dict)
+
+
+@dataclass(slots=True)
+class MCPConfig:
+    enabled: bool = True
+    servers: List[MCPServerConfig] = field(default_factory=list)
+
+
+@dataclass(slots=True)
+class RuntimeConfig:
+    llm: LLMConfig
+    agent: AgentConfig
+    mcp: MCPConfig
+
+
+def _load_toml(path: Path) -> Dict[str, Any]:
+    if not path.exists():
+        return {}
+    with path.open('rb') as handle:
+        return tomllib.load(handle)
+
+
+def _get_bool(value: Any, default: bool) -> bool:
+    if value is None:
+        return default
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, (int, float)):
+        return bool(value)
+    if isinstance(value, str):
+        lowered = value.strip().lower()
+        if lowered in {"1", "true", "yes", "on"}:
+            return True
+        if lowered in {"0", "false", "no", "off"}:
+            return False
+    return default
+
+
+def _load_mcp_servers(raw_servers: Iterable[Dict[str, Any]]) -> List[MCPServerConfig]:
+    servers: List[MCPServerConfig] = []
+    for raw in raw_servers:
+        name = str(raw.get('name'))
+        command = str(raw.get('command'))
+        if not name or not command:
+            continue
+        args = [str(item) for item in raw.get('args', [])]
+        cwd_value = raw.get('cwd')
+        cwd = Path(cwd_value) if cwd_value else None
+        env_raw = raw.get('env', {})
+        env = {str(k): str(v) for k, v in env_raw.items()}
+        servers.append(MCPServerConfig(name=name, command=command, args=args, cwd=cwd, env=env))
+    return servers
+
+
+def load_config(path: Optional[Path | str] = None) -> RuntimeConfig:
+    """Load configuration from TOML and environment variables."""
+
+    candidate_paths = []
+    if path:
+        candidate_paths.append(Path(path))
+    else:
+        candidate_paths.append(Path('config.toml'))
+        candidate_paths.append(Path('autonomous-agent/config.sample.toml'))
+
+    data: Dict[str, Any] = {}
+    for candidate in candidate_paths:
+        if candidate.exists():
+            data = _load_toml(candidate)
+            break
+
+    llm_data = data.get('llm', {}) if isinstance(data.get('llm'), dict) else {}
+    agent_data = data.get('agent', {}) if isinstance(data.get('agent'), dict) else {}
+    mcp_data = data.get('mcp', {}) if isinstance(data.get('mcp'), dict) else {}
+
+    llm = LLMConfig(
+        base_url=str(llm_data.get('base_url', LLMConfig.base_url)),
+        model=str(llm_data.get('model', LLMConfig.model)),
+        request_timeout=int(llm_data.get('request_timeout', LLMConfig.request_timeout)),
+        api_key=llm_data.get('api_key') or None,
+    )
+
+    workspace_value = agent_data.get('workspace', AgentConfig.workspace)
+    agent = AgentConfig(
+        workspace=Path(workspace_value) if workspace_value else AgentConfig.workspace,
+        auto_plan=_get_bool(agent_data.get('auto_plan'), AgentConfig.auto_plan),
+        max_iterations=int(agent_data.get('max_iterations', AgentConfig.max_iterations)),
+        reflection=_get_bool(agent_data.get('reflection'), AgentConfig.reflection),
+    )
+
+    mcp = MCPConfig(
+        enabled=_get_bool(mcp_data.get('enabled'), MCPConfig.enabled),
+        servers=_load_mcp_servers(mcp_data.get('servers', [])),
+    )
+
+    # Environment overrides
+    llm.base_url = os.getenv('AGENT_BASE_URL', llm.base_url)
+    llm.model = os.getenv('AGENT_MODEL', llm.model)
+    if os.getenv('AGENT_REQUEST_TIMEOUT'):
+        try:
+            llm.request_timeout = int(os.getenv('AGENT_REQUEST_TIMEOUT', llm.request_timeout))
+        except ValueError:
+            pass
+    llm.api_key = os.getenv('AGENT_API_KEY', llm.api_key)
+
+    if os.getenv('AGENT_WORKSPACE'):
+        agent.workspace = Path(os.getenv('AGENT_WORKSPACE'))
+    if os.getenv('AGENT_AUTO_PLAN'):
+        agent.auto_plan = _get_bool(os.getenv('AGENT_AUTO_PLAN'), agent.auto_plan)
+    if os.getenv('AGENT_MAX_ITERATIONS'):
+        try:
+            agent.max_iterations = int(os.getenv('AGENT_MAX_ITERATIONS', agent.max_iterations))
+        except ValueError:
+            pass
+    if os.getenv('AGENT_REFLECTION'):
+        agent.reflection = _get_bool(os.getenv('AGENT_REFLECTION'), agent.reflection)
+
+    if os.getenv('AGENT_MCP_ENABLED'):
+        mcp.enabled = _get_bool(os.getenv('AGENT_MCP_ENABLED'), mcp.enabled)
+
+    return RuntimeConfig(llm=llm, agent=agent, mcp=mcp)
+
+
+__all__ = [
+    'LLMConfig',
+    'AgentConfig',
+    'MCPConfig',
+    'MCPServerConfig',
+    'RuntimeConfig',
+    'load_config',
+]

--- a/autonomous-agent/autonomous_agent/llm_client.py
+++ b/autonomous-agent/autonomous_agent/llm_client.py
@@ -1,0 +1,85 @@
+"""Simple HTTP client for OpenAI compatible chat endpoints."""
+
+from __future__ import annotations
+
+import json
+import time
+from dataclasses import dataclass
+from typing import Iterable, List, Optional
+from urllib import request, error
+
+from .config import LLMConfig
+
+
+@dataclass(slots=True)
+class ChatMessage:
+    role: str
+    content: str
+
+
+@dataclass(slots=True)
+class ChatResponse:
+    content: str
+    raw: dict
+    latency: float
+
+
+class LLMError(RuntimeError):
+    """Raised when the LLM endpoint returns an error."""
+
+
+class LLMClient:
+    def __init__(self, config: LLMConfig):
+        self._config = config
+        self._endpoint = config.base_url.rstrip('/') + '/chat/completions'
+
+    def chat(self, messages: Iterable[ChatMessage], temperature: float = 0.2) -> ChatResponse:
+        payload = {
+            'model': self._config.model,
+            'messages': [msg.__dict__ for msg in messages],
+            'temperature': temperature,
+            'stream': False,
+        }
+
+        headers = {
+            'Content-Type': 'application/json',
+        }
+        if self._config.api_key:
+            headers['Authorization'] = f'Bearer {self._config.api_key}'
+
+        encoded = json.dumps(payload).encode('utf-8')
+        req = request.Request(
+            self._endpoint,
+            data=encoded,
+            headers=headers,
+            method='POST',
+        )
+        start = time.perf_counter()
+        try:
+            with request.urlopen(req, timeout=self._config.request_timeout) as response:
+                raw_body = response.read().decode('utf-8')
+        except error.HTTPError as exc:
+            detail = exc.read().decode('utf-8', errors='replace')
+            raise LLMError(f'HTTP error {exc.code}: {detail}') from exc
+        except error.URLError as exc:  # pragma: no cover - network error
+            raise LLMError(f'Failed to reach LLM endpoint: {exc.reason}') from exc
+
+        latency = time.perf_counter() - start
+        try:
+            decoded = json.loads(raw_body)
+        except json.JSONDecodeError as exc:
+            raise LLMError(f'Invalid JSON response: {exc}') from exc
+
+        choices: List[dict] = decoded.get('choices', [])
+        if not choices:
+            raise LLMError('LLM response did not contain choices')
+
+        message = choices[0].get('message') or {}
+        content = message.get('content')
+        if content is None:
+            raise LLMError('LLM response missing message content')
+
+        return ChatResponse(content=str(content), raw=decoded, latency=latency)
+
+
+__all__ = ['ChatMessage', 'ChatResponse', 'LLMClient', 'LLMError']

--- a/autonomous-agent/autonomous_agent/mcp/README.md
+++ b/autonomous-agent/autonomous_agent/mcp/README.md
@@ -1,0 +1,10 @@
+# MCP integration
+
+The agent can talk to Model Context Protocol servers using a lightweight JSON-RPC implementation. Each server is started as a subprocess and must implement the following methods:
+
+- `initialize(params)` – returns metadata about the server. The agent sends `{ "client": "autonomous-agent" }` as params.
+- `listTools()` – returns `{ "tools": [ { "name": "...", "description": "...", "parameters": {...} } ] }`.
+- `callTool({"name": "tool_name", "arguments": {...}})` – executes a tool and returns the result payload.
+- `shutdown()` – optional, called during graceful shutdown.
+
+Tools published through MCP become regular agent tools and can be invoked by the LLM. See `servers/filesystem.py` for an example server.

--- a/autonomous-agent/autonomous_agent/mcp/__init__.py
+++ b/autonomous-agent/autonomous_agent/mcp/__init__.py
@@ -1,0 +1,5 @@
+"""Simple Model Context Protocol integration."""
+
+from .manager import MCPManager
+
+__all__ = ['MCPManager']

--- a/autonomous-agent/autonomous_agent/mcp/manager.py
+++ b/autonomous-agent/autonomous_agent/mcp/manager.py
@@ -1,0 +1,160 @@
+"""MCP server integration utilities."""
+
+from __future__ import annotations
+
+import json
+import os
+import queue
+import subprocess
+import threading
+import uuid
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional
+
+from ..config import MCPConfig, MCPServerConfig
+from ..tools import Tool, ToolContext, ToolError, ToolRegistry
+
+
+class MCPConnectionError(RuntimeError):
+    pass
+
+
+class MCPClient:
+    def __init__(self, config: MCPServerConfig, workspace: str):
+        self._config = config
+        env = os.environ.copy()
+        env.setdefault('AGENT_WORKSPACE', workspace)
+        env.update(config.env or {})
+        args = [config.command, *config.args]
+        try:
+            self._process = subprocess.Popen(
+                args,
+                stdin=subprocess.PIPE,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                cwd=config.cwd,
+                env=env,
+                text=True,
+                bufsize=1,
+            )
+        except OSError as exc:  # pragma: no cover - depends on env
+            raise MCPConnectionError(f'Failed to start MCP server {config.name}: {exc}') from exc
+
+        if not self._process.stdin or not self._process.stdout:
+            raise MCPConnectionError('MCP server pipes not available')
+
+        self._stdin = self._process.stdin
+        self._stdout = self._process.stdout
+        self._responses: "queue.Queue[Dict[str, Any]]" = queue.Queue()
+        self._listener = threading.Thread(target=self._listen_loop, daemon=True)
+        self._listener.start()
+
+    def _listen_loop(self) -> None:
+        while True:
+            line = self._stdout.readline()
+            if not line:
+                break
+            try:
+                decoded = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if isinstance(decoded, dict):
+                self._responses.put(decoded)
+
+    def _request(self, method: str, params: Optional[Dict[str, Any]] = None, timeout: float = 10.0) -> Any:
+        message_id = str(uuid.uuid4())
+        payload = {
+            'jsonrpc': '2.0',
+            'id': message_id,
+            'method': method,
+            'params': params or {},
+        }
+        body = json.dumps(payload)
+        self._stdin.write(body + '\n')
+        self._stdin.flush()
+        while True:
+            try:
+                response = self._responses.get(timeout=timeout)
+            except queue.Empty as exc:
+                raise MCPConnectionError(f'MCP server timed out waiting for {method}') from exc
+            if response.get('id') == message_id:
+                if 'error' in response:
+                    raise MCPConnectionError(str(response['error']))
+                return response.get('result')
+
+    def initialize(self) -> Any:
+        return self._request('initialize', {'client': 'autonomous-agent'})
+
+    def list_tools(self) -> List[Dict[str, Any]]:
+        result = self._request('listTools')
+        tools = result.get('tools') if isinstance(result, dict) else None
+        return tools or []
+
+    def call_tool(self, name: str, arguments: Dict[str, Any]) -> Any:
+        return self._request('callTool', {'name': name, 'arguments': arguments})
+
+    def close(self) -> None:
+        try:
+            self._request('shutdown', {})
+        except MCPConnectionError:
+            pass
+        if self._process.poll() is None:
+            self._process.terminate()
+
+
+class RemoteTool(Tool):
+    def __init__(self, context: ToolContext, client: MCPClient, descriptor: Dict[str, Any]):
+        super().__init__(context)
+        self._client = client
+        self.name = descriptor.get('name', 'remote_tool')
+        self.description = descriptor.get('description', f'Remote tool from {client._config.name}')
+        parameters = descriptor.get('parameters', {})
+        try:
+            self.parameters = json.dumps(parameters)
+        except TypeError:
+            self.parameters = str(parameters)
+
+    def __call__(self, **kwargs) -> str:
+        result = self._client.call_tool(self.name, kwargs)
+        if isinstance(result, dict) and 'result' in result:
+            payload = result['result']
+        else:
+            payload = result
+        if isinstance(payload, str):
+            return payload
+        return json.dumps(payload, ensure_ascii=False)
+
+
+@dataclass(slots=True)
+class MCPServerHandle:
+    config: MCPServerConfig
+    client: MCPClient
+
+
+class MCPManager:
+    def __init__(self, mcp_config: MCPConfig, registry: ToolRegistry):
+        self._config = mcp_config
+        self._registry = registry
+        self._servers: List[MCPServerHandle] = []
+
+    def start(self) -> None:
+        if not self._config.enabled:
+            return
+        workspace = str(self._registry._context.workspace)
+        for server_cfg in self._config.servers:
+            client = MCPClient(server_cfg, workspace)
+            client.initialize()
+            tools = client.list_tools()
+            handle = MCPServerHandle(config=server_cfg, client=client)
+            self._servers.append(handle)
+            for tool in tools:
+                remote = RemoteTool(self._registry._context, client, tool)
+                self._registry.register(remote)
+
+    def shutdown(self) -> None:
+        for handle in self._servers:
+            handle.client.close()
+        self._servers.clear()
+
+
+__all__ = ['MCPManager', 'MCPConnectionError']

--- a/autonomous-agent/autonomous_agent/mcp/servers/filesystem.py
+++ b/autonomous-agent/autonomous_agent/mcp/servers/filesystem.py
@@ -1,0 +1,111 @@
+"""Reference MCP server exposing read-only filesystem tools."""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Any, Dict
+
+WORKSPACE = Path(os.getenv('AGENT_WORKSPACE', '.')).resolve()
+
+
+def within_workspace(path: Path) -> bool:
+    try:
+        return str(path.resolve()).startswith(str(WORKSPACE))
+    except OSError:
+        return False
+
+
+def read_file(arguments: Dict[str, Any]) -> Dict[str, Any]:
+    path = WORKSPACE / arguments.get('path', '')
+    path = path.resolve()
+    if not within_workspace(path):
+        raise ValueError('Path outside workspace')
+    if not path.exists():
+        raise FileNotFoundError(str(path))
+    return {'result': path.read_text(encoding='utf-8', errors='replace')}
+
+
+def list_directory(arguments: Dict[str, Any]) -> Dict[str, Any]:
+    path = WORKSPACE / arguments.get('path', '.')
+    path = path.resolve()
+    if not within_workspace(path):
+        raise ValueError('Path outside workspace')
+    if not path.exists() or not path.is_dir():
+        raise FileNotFoundError(str(path))
+    entries = []
+    for item in sorted(path.iterdir()):
+        entries.append({'name': item.name, 'type': 'directory' if item.is_dir() else 'file'})
+    return {'result': entries}
+
+
+TOOLS = {
+    'fs.read': {
+        'name': 'fs.read',
+        'description': 'Read a UTF-8 file relative to the workspace.',
+        'parameters': {'type': 'object', 'properties': {'path': {'type': 'string'}}},
+        'handler': read_file,
+    },
+    'fs.list': {
+        'name': 'fs.list',
+        'description': 'List files in a workspace directory.',
+        'parameters': {'type': 'object', 'properties': {'path': {'type': 'string'}}},
+        'handler': list_directory,
+    },
+}
+
+
+def send_response(message_id: Any, result: Any = None, error: Any = None) -> None:
+    payload = {'jsonrpc': '2.0', 'id': message_id}
+    if error is not None:
+        payload['error'] = {'message': str(error)}
+    else:
+        payload['result'] = result
+    sys.stdout.write(json.dumps(payload) + '\n')
+    sys.stdout.flush()
+
+
+def main() -> None:
+    for line in sys.stdin:
+        if not line.strip():
+            continue
+        try:
+            message = json.loads(line)
+        except json.JSONDecodeError as exc:
+            send_response(None, error=f'Invalid JSON: {exc}')
+            continue
+
+        method = message.get('method')
+        message_id = message.get('id')
+        params = message.get('params') or {}
+
+        try:
+            if method == 'initialize':
+                send_response(message_id, {'server': 'filesystem', 'workspace': str(WORKSPACE)})
+            elif method == 'listTools':
+                tools = [
+                    {k: v for k, v in desc.items() if k != 'handler'}
+                    for desc in TOOLS.values()
+                ]
+                send_response(message_id, {'tools': tools})
+            elif method == 'callTool':
+                name = params.get('name')
+                arguments = params.get('arguments') or {}
+                tool = TOOLS.get(name)
+                if not tool:
+                    raise ValueError(f'Unknown tool {name}')
+                result = tool['handler'](arguments)
+                send_response(message_id, result)
+            elif method == 'shutdown':
+                send_response(message_id, {'ok': True})
+                break
+            else:
+                raise ValueError(f'Unknown method {method}')
+        except Exception as exc:
+            send_response(message_id, error=str(exc))
+
+
+if __name__ == '__main__':
+    main()

--- a/autonomous-agent/autonomous_agent/planner.py
+++ b/autonomous-agent/autonomous_agent/planner.py
@@ -1,0 +1,59 @@
+"""Planning helper for the autonomous coding agent."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, List
+
+from .llm_client import ChatMessage, LLMClient
+from .utils import extract_json_blob
+
+
+@dataclass(slots=True)
+class PlanStep:
+    number: int
+    description: str
+
+
+@dataclass(slots=True)
+class Plan:
+    original_task: str
+    steps: List[PlanStep]
+
+    def summary(self) -> str:
+        joined = '\n'.join(f"{step.number}. {step.description}" for step in self.steps)
+        return f"Plan for: {self.original_task}\n{joined}" if joined else f"No plan generated for: {self.original_task}"
+
+
+class Planner:
+    def __init__(self, llm: LLMClient, prompt_path: Path):
+        self._llm = llm
+        self._prompt = prompt_path.read_text(encoding='utf-8')
+
+    def make_plan(self, task: str, tools: Iterable[str], max_steps: int = 8) -> Plan:
+        messages = [
+            ChatMessage(role='system', content=self._prompt.format(max_steps=max_steps)),
+            ChatMessage(
+                role='user',
+                content=(
+                    "You must create a plan for the following task as a JSON object.\n"
+                    f"Task: {task}\n"
+                    f"Available tools: {', '.join(tools)}"
+                ),
+            ),
+        ]
+        response = self._llm.chat(messages, temperature=0.1)
+        data = extract_json_blob(response.content)
+        raw_steps = data.get('plan') if isinstance(data, dict) else []
+        steps: List[PlanStep] = []
+        for index, item in enumerate(raw_steps or [], start=1):
+            if isinstance(item, dict):
+                description = item.get('description') or item.get('summary') or str(item)
+            else:
+                description = str(item)
+            steps.append(PlanStep(number=index, description=description.strip()))
+        return Plan(original_task=task, steps=steps)
+
+
+__all__ = ['Planner', 'Plan', 'PlanStep']

--- a/autonomous-agent/autonomous_agent/prompts/system_agent.txt
+++ b/autonomous-agent/autonomous_agent/prompts/system_agent.txt
@@ -1,0 +1,18 @@
+You are an autonomous coding agent inspired by Cursor. Your goal is to solve the user's task by reasoning step-by-step and by using the available tools.
+
+Guidelines:
+- Always think before acting. Explain your thought process in the "thought" field.
+- When you need to use a tool reply with JSON only using the following structure:
+  {
+    "thought": "",
+    "action": {"tool": "tool_name", "input": {"arg": "value"}}
+  }
+- If you have reached the final answer, respond with:
+  {
+    "thought": "",
+    "final": "your final response"
+  }
+- If a tool execution fails, analyse the error message and adjust your next action.
+- Prefer small, incremental changes and verify written files by reading them afterwards.
+- Use the plan as guidance but stay adaptive.
+- Never request unavailable tools.

--- a/autonomous-agent/autonomous_agent/prompts/system_planner.txt
+++ b/autonomous-agent/autonomous_agent/prompts/system_planner.txt
@@ -1,0 +1,10 @@
+You are an expert project planner for an autonomous coding assistant.
+Create a concise plan for the task provided by the user. Return a JSON object with the following structure:
+{
+  "plan": [
+    {"description": "..."}
+  ]
+}
+- Limit yourself to at most {max_steps} steps.
+- Each description must be actionable and less than 30 words.
+- Do not include any commentary outside of the JSON object.

--- a/autonomous-agent/autonomous_agent/tools.py
+++ b/autonomous-agent/autonomous_agent/tools.py
@@ -1,0 +1,165 @@
+"""Filesystem tools exposed to the agent."""
+
+from __future__ import annotations
+
+import io
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, List
+
+
+class ToolError(RuntimeError):
+    pass
+
+
+@dataclass(slots=True)
+class ToolContext:
+    workspace: Path
+
+    def resolve(self, relative: str) -> Path:
+        candidate = (self.workspace / relative).resolve()
+        if not str(candidate).startswith(str(self.workspace.resolve())):
+            raise ToolError('Attempt to access path outside workspace')
+        return candidate
+
+
+class Tool:
+    name: str = ''
+    description: str = ''
+    parameters: str = ''
+
+    def __init__(self, context: ToolContext):
+        self.context = context
+
+    def describe(self) -> Dict[str, str]:
+        return {
+            'name': self.name,
+            'description': self.description,
+            'parameters': self.parameters,
+        }
+
+    def __call__(self, **kwargs) -> str:  # pragma: no cover - abstract
+        raise NotImplementedError
+
+
+class ReadFileTool(Tool):
+    name = 'read_file'
+    description = 'Read a text file from the workspace.'
+    parameters = '{"path": "relative path"}'
+
+    def __call__(self, path: str) -> str:
+        file_path = self.context.resolve(path)
+        if not file_path.exists():
+            raise ToolError(f'File not found: {path}')
+        return file_path.read_text(encoding='utf-8', errors='replace')
+
+
+class WriteFileTool(Tool):
+    name = 'write_file'
+    description = 'Create or overwrite a text file with provided content.'
+    parameters = '{"path": "relative path", "content": "full file content"}'
+
+    def __call__(self, path: str, content: str) -> str:
+        file_path = self.context.resolve(path)
+        file_path.parent.mkdir(parents=True, exist_ok=True)
+        file_path.write_text(content, encoding='utf-8')
+        return f'Wrote {len(content)} characters to {path}'
+
+
+class AppendFileTool(Tool):
+    name = 'append_file'
+    description = 'Append text to an existing file, creating it if necessary.'
+    parameters = '{"path": "relative path", "content": "text to append"}'
+
+    def __call__(self, path: str, content: str) -> str:
+        file_path = self.context.resolve(path)
+        file_path.parent.mkdir(parents=True, exist_ok=True)
+        with file_path.open('a', encoding='utf-8') as handle:
+            handle.write(content)
+        return f'Appended {len(content)} characters to {path}'
+
+
+class ListDirectoryTool(Tool):
+    name = 'list_directory'
+    description = 'List files under a directory.'
+    parameters = '{"path": "relative directory"}'
+
+    def __call__(self, path: str = '.') -> str:
+        dir_path = self.context.resolve(path)
+        if not dir_path.exists():
+            raise ToolError(f'Directory not found: {path}')
+        if not dir_path.is_dir():
+            raise ToolError(f'Not a directory: {path}')
+        lines = []
+        for item in sorted(dir_path.iterdir()):
+            marker = '/' if item.is_dir() else ''
+            lines.append(item.name + marker)
+        return '\n'.join(lines)
+
+
+class SearchFileTool(Tool):
+    name = 'search_file'
+    description = 'Search for a regular expression inside a file.'
+    parameters = '{"path": "relative path", "pattern": "regular expression"}'
+
+    def __call__(self, path: str, pattern: str) -> str:
+        file_path = self.context.resolve(path)
+        if not file_path.exists():
+            raise ToolError(f'File not found: {path}')
+        text = file_path.read_text(encoding='utf-8', errors='replace')
+        matches = list(re.finditer(pattern, text, flags=re.MULTILINE))
+        if not matches:
+            return 'No matches found.'
+        output = io.StringIO()
+        for match in matches:
+            start = max(match.start() - 40, 0)
+            end = min(match.end() + 40, len(text))
+            snippet = text[start:end].replace('\n', '\\n')
+            output.write(f'{match.start()}-{match.end()}: {snippet}\n')
+        return output.getvalue().strip()
+
+
+class ToolRegistry:
+    def __init__(self, context: ToolContext):
+        self._context = context
+        self._tools: Dict[str, Tool] = {}
+
+    def register(self, tool_or_cls) -> None:
+        if isinstance(tool_or_cls, type):
+            tool = tool_or_cls(self._context)
+        else:
+            tool = tool_or_cls
+        self._tools[tool.name] = tool
+
+    def get(self, name: str) -> Tool:
+        if name not in self._tools:
+            raise ToolError(f'Unknown tool: {name}')
+        return self._tools[name]
+
+    def names(self) -> List[str]:
+        return sorted(self._tools.keys())
+
+    def describe(self) -> List[Dict[str, str]]:
+        return [tool.describe() for tool in self._tools.values()]
+
+    def execute(self, name: str, **kwargs) -> str:
+        tool = self.get(name)
+        return tool(**kwargs)
+
+
+def create_default_registry(workspace: Path) -> ToolRegistry:
+    context = ToolContext(workspace=workspace.resolve())
+    registry = ToolRegistry(context)
+    for tool_cls in (ReadFileTool, WriteFileTool, AppendFileTool, ListDirectoryTool, SearchFileTool):
+        registry.register(tool_cls)
+    return registry
+
+
+__all__ = [
+    'ToolContext',
+    'Tool',
+    'ToolRegistry',
+    'ToolError',
+    'create_default_registry',
+]

--- a/autonomous-agent/autonomous_agent/utils.py
+++ b/autonomous-agent/autonomous_agent/utils.py
@@ -1,0 +1,25 @@
+"""Utility helpers for the autonomous agent."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+
+def extract_json_blob(text: str) -> Any:
+    """Extract JSON from a text response.
+
+    The model is encouraged to respond with plain JSON, but we also try to strip
+    triple backtick code fences when present.
+    """
+
+    candidate = text.strip()
+    if candidate.startswith('```'):
+        lines = candidate.splitlines()
+        if len(lines) >= 3:
+            # Drop first and last line that contain fences
+            candidate = '\n'.join(lines[1:-1])
+    return json.loads(candidate)
+
+
+__all__ = ['extract_json_blob']

--- a/autonomous-agent/config.sample.toml
+++ b/autonomous-agent/config.sample.toml
@@ -1,0 +1,15 @@
+[llm]
+base_url = "http://llm:11434/v1"
+model = "llama3.1:8b-instruct"
+request_timeout = 120
+
+[agent]
+workspace = "."
+auto_plan = true
+max_iterations = 12
+
+[mcp]
+enabled = true
+servers = [
+  { name = "filesystem", command = "python", args = ["-m", "autonomous_agent.mcp.servers.filesystem"], cwd = "." }
+]

--- a/autonomous-agent/pyproject.toml
+++ b/autonomous-agent/pyproject.toml
@@ -1,0 +1,15 @@
+[build-system]
+requires = ["setuptools>=65"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "autonomous-agent"
+version = "0.1.0"
+description = "Autonomous coding agent with local LLM and MCP support"
+authors = [{name = "Binance AI Traders"}]
+readme = "README.md"
+requires-python = ">=3.11"
+dependencies = []
+
+[project.scripts]
+autonomous-agent = "autonomous_agent.cli:main"

--- a/autonomous-agent/tests/conftest.py
+++ b/autonomous-agent/tests/conftest.py
@@ -1,0 +1,8 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))

--- a/autonomous-agent/tests/test_agent.py
+++ b/autonomous-agent/tests/test_agent.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from autonomous_agent.agent import AutonomousCoderAgent
+from autonomous_agent.config import AgentConfig, LLMConfig, MCPConfig, RuntimeConfig
+from autonomous_agent.llm_client import ChatResponse
+
+
+class StubLLM:
+    def __init__(self, responses):
+        self._responses = list(responses)
+
+    def chat(self, messages, temperature=0.0):
+        if not self._responses:
+            raise AssertionError('No more stub responses')
+        content = self._responses.pop(0)
+        return ChatResponse(content=content, raw={}, latency=0.01)
+
+
+def test_agent_executes_tool(tmp_path):
+    runtime = RuntimeConfig(
+        llm=LLMConfig(base_url='http://localhost', model='test'),
+        agent=AgentConfig(workspace=tmp_path, auto_plan=False, max_iterations=3),
+        mcp=MCPConfig(enabled=False, servers=[]),
+    )
+    tmp_path.mkdir(exist_ok=True)
+    stub_llm = StubLLM([
+        '{"thought": "Check directory", "action": {"tool": "list_directory", "input": {"path": "."}}}',
+        '{"thought": "Done", "final": "Listed directory"}'
+    ])
+    agent = AutonomousCoderAgent(runtime, llm=stub_llm)
+    result = agent.run('List project files')
+    assert result.final_response == 'Listed directory'
+    assert any(call['tool'] == 'list_directory' for call in result.tool_calls)

--- a/autonomous-agent/tests/test_config.py
+++ b/autonomous-agent/tests/test_config.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from autonomous_agent.config import load_config
+
+
+def test_load_config_with_env_overrides(tmp_path, monkeypatch):
+    config_path = tmp_path / 'config.toml'
+    config_path.write_text(
+        """
+[llm]
+base_url = "http://example.com"
+model = "base"
+request_timeout = 30
+
+[agent]
+workspace = "{workspace}"
+auto_plan = false
+max_iterations = 5
+
+[mcp]
+enabled = false
+""".format(workspace=tmp_path / 'ws')
+    )
+
+    monkeypatch.setenv('AGENT_MODEL', 'override-model')
+    monkeypatch.setenv('AGENT_MAX_ITERATIONS', '9')
+
+    runtime = load_config(config_path)
+    assert runtime.llm.model == 'override-model'
+    assert runtime.agent.max_iterations == 9
+    assert runtime.agent.auto_plan is False
+    assert runtime.mcp.enabled is False

--- a/autonomous-agent/tests/test_planner.py
+++ b/autonomous-agent/tests/test_planner.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from autonomous_agent.llm_client import ChatResponse
+from autonomous_agent.planner import Planner
+
+
+class StubLLM:
+    def __init__(self, response: str):
+        self._response = response
+
+    def chat(self, messages, temperature=0.0):
+        return ChatResponse(content=self._response, raw={}, latency=0.01)
+
+
+def test_planner_parses_plan(tmp_path):
+    prompt_path = tmp_path / 'prompt.txt'
+    prompt_path.write_text('prompt {max_steps}')
+    llm = StubLLM('{"plan": [{"description": "Step one"}, {"description": "Step two"}]}')
+    planner = Planner(llm, prompt_path)
+    plan = planner.make_plan('Do stuff', ['read_file'])
+    assert [step.description for step in plan.steps] == ['Step one', 'Step two']

--- a/docker-compose.agent.yml
+++ b/docker-compose.agent.yml
@@ -1,0 +1,29 @@
+version: "3.9"
+
+services:
+  llm:
+    image: ollama/ollama:latest
+    container_name: local-ollama
+    restart: unless-stopped
+    ports:
+      - "11434:11434"
+    volumes:
+      - ollama-data:/root/.ollama
+
+  agent:
+    build:
+      context: ./autonomous-agent
+    environment:
+      - AGENT_BASE_URL=http://llm:11434/v1
+      - AGENT_MODEL=llama3.1:8b-instruct
+      - AGENT_WORKSPACE=/workspace
+      - AGENT_CONFIG=/workspace/config.toml
+    volumes:
+      - ./:/workspace
+    depends_on:
+      - llm
+    working_dir: /workspace
+    command: ["autonomous-agent", "--task", "Describe the repository"]
+
+volumes:
+  ollama-data:


### PR DESCRIPTION
## Summary
- add a new `autonomous-agent` package that loads configuration, plans tasks, and orchestrates tools with MCP support
- expose a CLI, Dockerfile, and Docker Compose flow to run the agent alongside a local Ollama LLM
- document setup steps and add unit tests covering the config loader, planner, and agent loop

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d699775cc88329b80136269c39ed34