### PR TITLE
Add MACD trader requirements documentation and test suite

### DIFF
--- a/binance-trader-macd/src/test/java/com/oyakov/binance_trader_macd/domain/signal/MACDSignalAnalyzerTest.java
+++ b/binance-trader-macd/src/test/java/com/oyakov/binance_trader_macd/domain/signal/MACDSignalAnalyzerTest.java
@@ -1,0 +1,82 @@
+package com.oyakov.binance_trader_macd.domain.signal;
+
+import com.oyakov.binance_shared_model.avro.KlineEvent;
+import com.oyakov.binance_trader_macd.domain.TradeSignal;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class MACDSignalAnalyzerTest {
+
+    private MACDSignalAnalyzer analyzer;
+
+    @BeforeEach
+    void setUp() {
+        analyzer = new MACDSignalAnalyzer();
+    }
+
+    @Test
+    void shouldRequireMinimumDataPointsBeforeProducingSignal() {
+        List<KlineEvent> klines = buildSinusoidalKlines(analyzer.getMinDataPointCount() - 1);
+
+        Optional<TradeSignal> signal = analyzer.tryExtractSignal(klines);
+
+        assertThat(signal).isEmpty();
+    }
+
+    @Test
+    void shouldGenerateBuySignalWhenMacdCrossesAboveSignalLine() {
+        List<KlineEvent> klines = buildSinusoidalKlines(62);
+
+        Optional<TradeSignal> signal = analyzer.tryExtractSignal(klines);
+
+        assertThat(signal).contains(TradeSignal.BUY);
+    }
+
+    @Test
+    void shouldGenerateSellSignalWhenMacdCrossesBelowSignalLine() {
+        List<KlineEvent> klines = buildSinusoidalKlines(78);
+
+        Optional<TradeSignal> signal = analyzer.tryExtractSignal(klines);
+
+        assertThat(signal).contains(TradeSignal.SELL);
+    }
+
+    @Test
+    void shouldReturnEmptyWhenMacdRemainsOnSameSideOfSignalLine() {
+        List<KlineEvent> klines = buildSinusoidalKlines(60);
+
+        Optional<TradeSignal> signal = analyzer.tryExtractSignal(klines);
+
+        assertThat(signal).isEmpty();
+    }
+
+    private List<KlineEvent> buildSinusoidalKlines(int length) {
+        List<KlineEvent> klines = new ArrayList<>(length);
+        for (int i = 0; i < length; i++) {
+            BigDecimal price = BigDecimal.valueOf(100 + 10 * Math.sin(i / 5.0))
+                    .setScale(8, RoundingMode.HALF_UP);
+            klines.add(new KlineEvent(
+                    "kline",
+                    (long) i,
+                    "BTCUSDT",
+                    "1m",
+                    (long) i,
+                    (long) i,
+                    price,
+                    price,
+                    price,
+                    price,
+                    BigDecimal.ONE
+            ));
+        }
+        return klines;
+    }
+}

--- a/binance-trader-macd/src/test/java/com/oyakov/binance_trader_macd/integration/MacdBacktestIntegrationTest.java
+++ b/binance-trader-macd/src/test/java/com/oyakov/binance_trader_macd/integration/MacdBacktestIntegrationTest.java
@@ -1,0 +1,60 @@
+package com.oyakov.binance_trader_macd.integration;
+
+import com.oyakov.binance_shared_model.avro.KlineEvent;
+import com.oyakov.binance_trader_macd.domain.TradeSignal;
+import com.oyakov.binance_trader_macd.domain.signal.MACDSignalAnalyzer;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class MacdBacktestIntegrationTest {
+
+    private final MACDSignalAnalyzer analyzer = new MACDSignalAnalyzer();
+
+    @Test
+    void shouldEmitExpectedSignalSequenceDuringBacktestReplay() {
+        List<KlineEvent> dataset = buildSinusoidalKlines(120);
+        List<TradeSignal> signals = new ArrayList<>();
+
+        for (int end = 0; end < dataset.size(); end++) {
+            List<KlineEvent> window = dataset.subList(0, end + 1);
+            analyzer.tryExtractSignal(window).ifPresent(signals::add);
+        }
+
+        assertThat(signals)
+                .containsExactly(
+                        TradeSignal.SELL,
+                        TradeSignal.BUY,
+                        TradeSignal.SELL,
+                        TradeSignal.BUY,
+                        TradeSignal.SELL
+                );
+    }
+
+    private List<KlineEvent> buildSinusoidalKlines(int length) {
+        List<KlineEvent> klines = new ArrayList<>(length);
+        for (int i = 0; i < length; i++) {
+            BigDecimal price = BigDecimal.valueOf(100 + 10 * Math.sin(i / 5.0))
+                    .setScale(8, RoundingMode.HALF_UP);
+            klines.add(new KlineEvent(
+                    "kline",
+                    (long) i,
+                    "BTCUSDT",
+                    "1m",
+                    (long) i,
+                    (long) i,
+                    price,
+                    price,
+                    price,
+                    price,
+                    BigDecimal.ONE
+            ));
+        }
+        return klines;
+    }
+}

--- a/binance-trader-macd/src/test/java/com/oyakov/binance_trader_macd/service/impl/OrderServiceImplTest.java
+++ b/binance-trader-macd/src/test/java/com/oyakov/binance_trader_macd/service/impl/OrderServiceImplTest.java
@@ -1,0 +1,150 @@
+package com.oyakov.binance_trader_macd.service.impl;
+
+import com.oyakov.binance_trader_macd.domain.OrderSide;
+import com.oyakov.binance_trader_macd.domain.OrderState;
+import com.oyakov.binance_trader_macd.domain.OrderType;
+import com.oyakov.binance_trader_macd.domain.TimeInForce;
+import com.oyakov.binance_trader_macd.exception.OrderCapacityReachedException;
+import com.oyakov.binance_trader_macd.model.order.binance.storage.OrderItem;
+import com.oyakov.binance_trader_macd.repository.jpa.OrderPostgresRepository;
+import com.oyakov.binance_trader_macd.rest.client.BinanceOrderClient;
+import com.oyakov.binance_trader_macd.rest.dto.BinanceOcoOrderResponse;
+import com.oyakov.binance_trader_macd.rest.dto.BinanceOrderResponse;
+import com.oyakov.binance_trader_macd.service.api.OrderServiceApi;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.core.convert.ConversionService;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class OrderServiceImplTest {
+
+    private static final String SYMBOL = "BTCUSDT";
+
+    @Mock
+    private BinanceOrderClient binanceOrderClient;
+    @Mock
+    private OrderPostgresRepository orderRepository;
+    @Mock
+    private ConversionService conversionService;
+
+    private OrderServiceApi orderService;
+
+    @BeforeEach
+    void setUp() {
+        orderService = new OrderServiceImpl(binanceOrderClient, orderRepository, conversionService);
+    }
+
+    @Test
+    void shouldThrowWhenActiveOrderAlreadyExists() {
+        OrderItem existing = OrderItem.builder().symbol(SYMBOL).status(OrderState.ACTIVE).build();
+        when(orderRepository.findBySymbolAndStatusEquals(SYMBOL, OrderState.ACTIVE)).thenReturn(Optional.of(existing));
+
+        assertThatThrownBy(() -> orderService.createOrderGroup(
+                SYMBOL,
+                BigDecimal.TEN,
+                BigDecimal.ONE,
+                OrderSide.BUY,
+                BigDecimal.valueOf(9),
+                BigDecimal.valueOf(11)
+        )).isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("Active order exists");
+
+        verify(binanceOrderClient, never()).placeOrder(any(), any(), any(), any(), any(), any(), any());
+    }
+
+    @Test
+    void shouldCreateOrderGroupAndPersistOrders() throws OrderCapacityReachedException {
+        when(orderRepository.findBySymbolAndStatusEquals(SYMBOL, OrderState.ACTIVE)).thenReturn(Optional.empty());
+
+        BinanceOrderResponse mainResponse = new BinanceOrderResponse();
+        mainResponse.setSymbol(SYMBOL);
+        mainResponse.setOrderId(123L);
+        mainResponse.setType(OrderType.LIMIT.name());
+        mainResponse.setSide(OrderSide.BUY.name());
+        OrderItem entryOrder = OrderItem.builder().orderId(123L).symbol(SYMBOL).status(OrderState.NEW).build();
+        when(binanceOrderClient.placeOrder(SYMBOL, OrderType.LIMIT, OrderSide.BUY,
+                BigDecimal.ONE, BigDecimal.TEN, null, TimeInForce.GTC)).thenReturn(mainResponse);
+        when(conversionService.convert(mainResponse, OrderItem.class)).thenReturn(entryOrder);
+
+        BinanceOcoOrderResponse.OrderReport report = new BinanceOcoOrderResponse.OrderReport();
+        report.setOrderId(456L);
+        BinanceOcoOrderResponse ocoResponse = new BinanceOcoOrderResponse();
+        ocoResponse.setOrderReports(List.of(report));
+        when(binanceOrderClient.placeOcoOrder(eq(SYMBOL), eq(OrderSide.SELL), eq(BigDecimal.ONE),
+                any(), any(), any(), any())).thenReturn(ocoResponse);
+        OrderItem ocoOrder = OrderItem.builder().orderId(456L).symbol(SYMBOL).status(OrderState.NEW).build();
+        when(conversionService.convert(report, OrderItem.class)).thenReturn(ocoOrder);
+
+        OrderItem result = orderService.createOrderGroup(
+                SYMBOL,
+                BigDecimal.TEN,
+                BigDecimal.ONE,
+                OrderSide.BUY,
+                BigDecimal.valueOf(9),
+                BigDecimal.valueOf(11)
+        );
+
+        assertThat(result).isSameAs(entryOrder);
+        verify(orderRepository).save(entryOrder);
+        verify(orderRepository).saveAll(any());
+    }
+
+    @Test
+    void shouldCancelAndUpdateOrderStateWhenClosing() {
+        OrderItem storedOrder = OrderItem.builder()
+                .orderId(321L)
+                .symbol(SYMBOL)
+                .status(OrderState.NEW)
+                .build();
+        when(orderRepository.findById(321L)).thenReturn(Optional.of(storedOrder));
+        when(binanceOrderClient.cancelOrder(SYMBOL, 321L)).thenReturn(true);
+
+        orderService.closeOrderWithState(321L, OrderState.CLOSED_SL);
+
+        verify(binanceOrderClient).cancelOrder(SYMBOL, 321L);
+        verify(orderRepository).updateOrderState(321L, OrderState.CLOSED_SL);
+    }
+
+    @Test
+    void shouldNotUpdateStateWhenCancelFails() {
+        OrderItem storedOrder = OrderItem.builder()
+                .orderId(999L)
+                .symbol(SYMBOL)
+                .status(OrderState.NEW)
+                .build();
+        when(orderRepository.findById(999L)).thenReturn(Optional.of(storedOrder));
+        when(binanceOrderClient.cancelOrder(SYMBOL, 999L)).thenReturn(false);
+
+        orderService.closeOrderWithState(999L, OrderState.CLOSED_TP);
+
+        verify(orderRepository, never()).updateOrderState(anyLong(), any());
+    }
+
+    @Test
+    void shouldDelegateActiveOrderLookups() {
+        OrderItem active = OrderItem.builder().orderId(777L).symbol(SYMBOL).status(OrderState.ACTIVE).build();
+        when(orderRepository.findBySymbolAndStatusEquals(SYMBOL, OrderState.ACTIVE)).thenReturn(Optional.of(active));
+
+        assertThat(orderService.getActiveOrder(SYMBOL)).contains(active);
+        assertThat(orderService.hasActiveOrder(SYMBOL)).isTrue();
+
+        verify(orderRepository, times(2)).findBySymbolAndStatusEquals(SYMBOL, OrderState.ACTIVE);
+    }
+}

--- a/binance-trader-macd/src/test/java/com/oyakov/binance_trader_macd/service/impl/TraderServiceImplTest.java
+++ b/binance-trader-macd/src/test/java/com/oyakov/binance_trader_macd/service/impl/TraderServiceImplTest.java
@@ -1,0 +1,110 @@
+package com.oyakov.binance_trader_macd.service.impl;
+
+import com.oyakov.binance_shared_model.avro.KlineEvent;
+import com.oyakov.binance_trader_macd.config.MACDTraderConfig;
+import com.oyakov.binance_trader_macd.domain.TradeSignal;
+import com.oyakov.binance_trader_macd.domain.signal.MACDSignalAnalyzer;
+import com.oyakov.binance_trader_macd.service.api.OrderServiceApi;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.util.Optional;
+import java.util.stream.StreamSupport;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class TraderServiceImplTest {
+
+    private static final String SYMBOL = "BTCUSDT";
+
+    @Mock
+    private MACDSignalAnalyzer macdSignalAnalyzer;
+    @Mock
+    private OrderServiceApi orderService;
+
+    private TraderServiceImpl traderService;
+
+    @BeforeEach
+    void setUp() {
+        MACDTraderConfig config = new MACDTraderConfig();
+        MACDTraderConfig.Trader trader = config.getTrader();
+        trader.setSlidingWindowSize(5);
+        trader.setOrderQuantity(BigDecimal.valueOf(0.1));
+        trader.setStopLossPercentage(BigDecimal.valueOf(0.98));
+        trader.setTakeProfitPercentage(BigDecimal.valueOf(1.05));
+
+        traderService = new TraderServiceImpl(macdSignalAnalyzer, orderService, config);
+        ReflectionTestUtils.invokeMethod(traderService, "init");
+    }
+
+    @Test
+    void shouldNotAttemptSignalExtractionUntilWindowIsFilled() {
+        for (int i = 0; i < 4; i++) {
+            traderService.onNewKline(kline(i, BigDecimal.valueOf(100 + i)));
+        }
+
+        verifyNoInteractions(macdSignalAnalyzer);
+        verifyNoInteractions(orderService);
+    }
+
+    @Test
+    void shouldRequestSignalAndCheckActiveOrderOnFullWindow() {
+        when(macdSignalAnalyzer.tryExtractSignal(any())).thenReturn(Optional.empty());
+        when(orderService.getActiveOrder(SYMBOL)).thenReturn(Optional.empty());
+
+        for (int i = 0; i < 5; i++) {
+            traderService.onNewKline(kline(i, BigDecimal.valueOf(100 + i)));
+        }
+
+        ArgumentCaptor<Iterable<KlineEvent>> captor = ArgumentCaptor.forClass(Iterable.class);
+        verify(macdSignalAnalyzer, times(1)).tryExtractSignal(captor.capture());
+        long capturedSize = StreamSupport.stream(captor.getValue().spliterator(), false).count();
+        assertThat(capturedSize).isEqualTo(5);
+
+        verify(orderService).getActiveOrder(SYMBOL);
+    }
+
+    @Test
+    void shouldSkipOrderLookupWhenSignalIsPresent() {
+        when(macdSignalAnalyzer.tryExtractSignal(any())).thenReturn(Optional.of(TradeSignal.BUY));
+
+        for (int i = 0; i < 5; i++) {
+            traderService.onNewKline(kline(i, BigDecimal.valueOf(100 + i)));
+        }
+
+        verify(macdSignalAnalyzer, times(1)).tryExtractSignal(any());
+        verify(orderService, never()).getActiveOrder(anyString());
+    }
+
+    private KlineEvent kline(int index, BigDecimal price) {
+        BigDecimal rounded = price.setScale(8, RoundingMode.HALF_UP);
+        return new KlineEvent(
+                "kline",
+                (long) index,
+                SYMBOL,
+                "1m",
+                (long) index,
+                (long) index,
+                rounded,
+                rounded,
+                rounded,
+                rounded,
+                BigDecimal.ONE
+        );
+    }
+}

--- a/docs/requirements-macd-trader.md
+++ b/docs/requirements-macd-trader.md
@@ -1,0 +1,26 @@
+# MACD Trader Service Requirements
+
+## Functional Scope
+- Consume Binance kline events and maintain a sliding processing window sized by configuration (`binance.trader.slidingWindowSize`).
+- Derive MACD-based trade signals (BUY/SELL) using 12/26-period EMAs and a 9-period signal line computed with precision scale 10.
+- When the sliding window lacks sufficient klines (`< 35`), skip trading decisions.
+- On each full window:
+  - Request a trade signal from `MACDSignalAnalyzer`.
+  - If a signal is produced, execute trade-side handling (currently logging and future order orchestration).
+  - If no signal, treat the kline as an update and inspect active orders for SL/TP handling.
+- Manage Binance order lifecycle via `OrderServiceImpl`, which must:
+  - Reject new order groups when an active order already exists for a symbol.
+  - Place a primary LIMIT order plus OCO stop-loss/take-profit contingent orders.
+  - Persist order metadata to PostgreSQL/Elasticsearch via `OrderPostgresRepository`.
+  - Close orders by cancelling them on Binance and updating stored state.
+
+## Non-Functional Requirements
+- Guard `TraderServiceImpl` sliding window with locking to avoid concurrent mutation.
+- Use Spring-managed configuration properties for REST/websocket endpoints and trader thresholds.
+- Ensure repository methods are transactional and use pessimistic locks where needed.
+- Converter logic must translate Binance API responses into internal `OrderItem` records using enum mappings.
+
+## External Dependencies
+- Relies on Binance REST API via `BinanceOrderClient` using API key/secret signing.
+- Uses Kafka Avro `KlineEvent` schema from `binance-shared-model` for market data interchange.
+- Persists and queries orders through Spring Data JPA/Elasticsearch repositories.

--- a/docs/test-plan-macd-trader.md
+++ b/docs/test-plan-macd-trader.md
@@ -1,0 +1,32 @@
+# MACD Trader Test Plan
+
+## Objectives
+- Validate MACD signal generation across bullish/bearish crossovers using deterministic kline sequences.
+- Exercise trader sliding-window orchestration for signal vs. non-signal paths.
+- Verify order service orchestration around placement, duplication guards, and closure semantics.
+- Simulate a backtesting loop over historical-style data to ensure consistent signal sequencing.
+
+## Scope & Coverage Matrix
+| Requirement | Test Type | Coverage Approach |
+|-------------|-----------|-------------------|
+| MACD EMA computation and signal extraction | Unit | Feed synthetic kline series that produce BUY, SELL, and neutral outcomes. |
+| Sliding window gating & order update checks | Unit | Drive `TraderServiceImpl` with mocked analyzer/service dependencies. |
+| Order placement workflow (limit + OCO) | Unit | Mock Binance client & repositories to assert interactions and guard rails. |
+| Order closure & active order lookup | Unit | Exercise `closeOrderWithState`, `getActiveOrder`, and `hasActiveOrder` logic. |
+| Backtesting of MACD strategy | Integration | Replay a sinusoidal kline dataset, capturing the sequence of emitted trade signals. |
+
+## Test Data
+- Deterministic sinusoidal price curve (`f(t) = 100 + 10 sin(t/5)`) converted into Avro `KlineEvent` fixtures, producing alternating MACD crossovers.
+- Boundary datasets with insufficient (<35) and exactly window-sized klines.
+- Stubbed Binance API responses for order placement and OCO order reports.
+
+## Execution Strategy
+1. Implement unit tests under `binance-trader-macd` with Mockito + JUnit 5.
+2. Implement integration-style test using the real `MACDSignalAnalyzer` processing the synthetic dataset end-to-end.
+3. Run `mvn test -pl binance-trader-macd` to execute the new suite.
+4. Integrate into CI by ensuring tests live in the module's standard `src/test/java` tree.
+
+## Exit Criteria
+- All new and existing tests pass without flaky behavior.
+- Coverage includes positive and negative paths for MACD signal extraction, trader window management, and order service workflow.
+- Backtesting integration test validates expected alternating signal sequence without exceptions.


### PR DESCRIPTION
## Summary
- document the MACD trader requirements and derived coverage plan in the docs folder
- add unit tests for the MACD signal analyzer plus trader and order service orchestration logic
- backtest the MACD signal analyzer against a deterministic sinusoidal dataset to validate crossover sequencing

## Testing
- mvn -f binance-trader-macd/pom.xml test *(fails: snapshot parent org.springframework.boot:spring-boot-starter-parent:3.4.0-SNAPSHOT returns HTTP 403 from spring-snapshots repo)*

------
https://chatgpt.com/codex/tasks/task_e_68dc10c13b64832995733a976ce28ed9