### PR TITLE
Restore MACD trader order handling logic

### DIFF
--- a/binance-trader-macd/src/main/java/com/oyakov/binance_trader_macd/service/impl/TraderServiceImpl.java
+++ b/binance-trader-macd/src/main/java/com/oyakov/binance_trader_macd/service/impl/TraderServiceImpl.java
@@ -102,18 +102,16 @@ public class TraderServiceImpl implements KlineEventListener {
         BigDecimal ratio = currentPrice.divide(entryPrice, RoundingMode.HALF_UP);
         log.info("SLTP - %s / %s = %s".formatted(entryPrice, currentPrice, ratio));
 
-        // TODO: check if SLTP is handled automatically by OCO LIMIT, i.e. we shouldn't be cancelling any orders, just log the ratio for now
-        // TODO: need to monitor order updates somehow to understand that the order has been closed, maybe also with websocket?
-//        if (ratio.compareTo(TAKE_PROFIT_THRESHOLD) > 0) {
-//            log.info("Close the deal, take profit threshold crossed");
-//            orderService.closeOrderWithState(orderId, OrderState.CLOSED_TP);
-//        } else {
-//            log.info("Take profit threshold not reached yet");
-//            if (ratio.compareTo(STOP_LOSS_THRESHOLD) < 0) {
-//                log.warn("Stop loss threshold has been crossed for the order %s. Triggering order cancellation...".formatted(orderId));
-//                orderService.closeOrderWithState(orderId, OrderState.CLOSED_SL);
-//            }
-//        }
+        if (ratio.compareTo(TAKE_PROFIT_THRESHOLD) > 0) {
+            log.info("Close the deal, take profit threshold crossed");
+            orderService.closeOrderWithState(orderId, OrderState.CLOSED_TP);
+        } else {
+            log.info("Take profit threshold not reached yet");
+            if (ratio.compareTo(STOP_LOSS_THRESHOLD) < 0) {
+                log.warn("Stop loss threshold has been crossed for the order %s. Triggering order cancellation...".formatted(orderId));
+                orderService.closeOrderWithState(orderId, OrderState.CLOSED_SL);
+            }
+        }
     }
 
     private void processTradeSignalUpdate(Long orderId, OrderSide orderSide, OrderSide signalSide) {
@@ -126,20 +124,19 @@ public class TraderServiceImpl implements KlineEventListener {
         String symbol = klineEvent.getSymbol();
         BigDecimal currentPrice = klineEvent.getClose();
         log.info("%s signal is triggered for symbol %s at price %s".formatted(OrderSide.of(signal), symbol, currentPrice));
-//        orderService.getActiveOrder(symbol).ifPresentOrElse(
-//                orderItem -> {
-//                    log.info("Active order present: %s".formatted(orderItem));
-//                    processOrderSLTP(orderItem.getOrderId(), orderItem.getPrice(), currentPrice);
-//                    processTradeSignalUpdate(orderItem.getOrderId(), orderItem.getSide(), OrderSide.of(signal));
-//                },
-//                () -> {
-//                    log.info("No active order detected, creating a new one...");
-//                    // Create order with stop-loss and take-profit
-//                    OrderItem order = orderService.createOrderGroup(
-//                            symbol, currentPrice, QUANTITY, OrderSide.of(signal),
-//                            currentPrice.multiply(STOP_LOSS_THRESHOLD), // stop loss price
-//                            currentPrice.multiply(TAKE_PROFIT_THRESHOLD)); // take profit price
-//                    log.info("Order group created: %s".formatted(order));
-//                });
+        orderService.getActiveOrder(symbol).ifPresentOrElse(
+                orderItem -> {
+                    log.info("Active order present: %s".formatted(orderItem));
+                    processOrderSLTP(orderItem.getOrderId(), orderItem.getPrice(), currentPrice);
+                    processTradeSignalUpdate(orderItem.getOrderId(), orderItem.getSide(), OrderSide.of(signal));
+                },
+                () -> {
+                    log.info("No active order detected, creating a new one...");
+                    OrderItem order = orderService.createOrderGroup(
+                            symbol, currentPrice, QUANTITY, OrderSide.of(signal),
+                            currentPrice.multiply(STOP_LOSS_THRESHOLD),
+                            currentPrice.multiply(TAKE_PROFIT_THRESHOLD));
+                    log.info("Order group created: %s".formatted(order));
+                });
     }
 }

--- a/binance-trader-macd/src/test/java/com/oyakov/binance_trader_macd/service/impl/TraderServiceImplTest.java
+++ b/binance-trader-macd/src/test/java/com/oyakov/binance_trader_macd/service/impl/TraderServiceImplTest.java
@@ -1,0 +1,141 @@
+package com.oyakov.binance_trader_macd.service.impl;
+
+import com.oyakov.binance_shared_model.avro.KlineEvent;
+import com.oyakov.binance_trader_macd.config.MACDTraderConfig;
+import com.oyakov.binance_trader_macd.domain.OrderSide;
+import com.oyakov.binance_trader_macd.domain.OrderState;
+import com.oyakov.binance_trader_macd.domain.TradeSignal;
+import com.oyakov.binance_trader_macd.domain.signal.MACDSignalAnalyzer;
+import com.oyakov.binance_trader_macd.model.order.binance.storage.OrderItem;
+import com.oyakov.binance_trader_macd.service.api.OrderServiceApi;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.Optional;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBigDecimal;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class TraderServiceImplTest {
+
+    private static final String SYMBOL = "BTCUSDT";
+    private static final BigDecimal ENTRY_PRICE = BigDecimal.valueOf(100);
+    private static final BigDecimal ORDER_QUANTITY = BigDecimal.valueOf(0.1);
+    private static final BigDecimal STOP_LOSS_THRESHOLD = BigDecimal.valueOf(0.95);
+    private static final BigDecimal TAKE_PROFIT_THRESHOLD = BigDecimal.valueOf(1.05);
+
+    @Mock
+    private MACDSignalAnalyzer macdSignalAnalyzer;
+
+    @Mock
+    private OrderServiceApi orderServiceApi;
+
+    private TraderServiceImpl traderService;
+
+    @BeforeEach
+    void setUp() {
+        MACDTraderConfig config = new MACDTraderConfig();
+        config.getTrader().setSlidingWindowSize(1);
+        config.getTrader().setOrderQuantity(ORDER_QUANTITY);
+        config.getTrader().setStopLossPercentage(STOP_LOSS_THRESHOLD);
+        config.getTrader().setTakeProfitPercentage(TAKE_PROFIT_THRESHOLD);
+
+        traderService = new TraderServiceImpl(macdSignalAnalyzer, orderServiceApi, config);
+        ReflectionTestUtils.invokeMethod(traderService, "init");
+    }
+
+    @Test
+    void shouldCreateOrderGroupWhenSignalEmittedAndNoActiveOrder() {
+        BigDecimal currentPrice = BigDecimal.valueOf(110);
+        when(macdSignalAnalyzer.tryExtractSignal(any())).thenReturn(Optional.of(TradeSignal.BUY));
+        when(orderServiceApi.getActiveOrder(SYMBOL)).thenReturn(Optional.empty());
+
+        traderService.onNewKline(buildKlineEvent(currentPrice));
+
+        verify(orderServiceApi).createOrderGroup(
+                eq(SYMBOL),
+                eq(currentPrice),
+                eq(ORDER_QUANTITY),
+                eq(OrderSide.BUY),
+                argThat(value -> value.compareTo(currentPrice.multiply(STOP_LOSS_THRESHOLD)) == 0),
+                argThat(value -> value.compareTo(currentPrice.multiply(TAKE_PROFIT_THRESHOLD)) == 0)
+        );
+        verify(orderServiceApi, never()).closeOrderWithState(anyLong(), any(OrderState.class));
+    }
+
+    @Test
+    void shouldCloseOrderWhenSignalOppositeToActiveOrder() {
+        BigDecimal currentPrice = ENTRY_PRICE;
+        OrderItem orderItem = new OrderItem();
+        orderItem.setOrderId(1L);
+        orderItem.setPrice(ENTRY_PRICE);
+        orderItem.setSide(OrderSide.SELL);
+
+        when(macdSignalAnalyzer.tryExtractSignal(any())).thenReturn(Optional.of(TradeSignal.BUY));
+        when(orderServiceApi.getActiveOrder(SYMBOL)).thenReturn(Optional.of(orderItem));
+
+        traderService.onNewKline(buildKlineEvent(currentPrice));
+
+        verify(orderServiceApi).closeOrderWithState(1L, OrderState.CLOSED_INVERTED_SIGNAL);
+        verify(orderServiceApi, never()).createOrderGroup(
+                anyString(), anyBigDecimal(), anyBigDecimal(), any(OrderSide.class), anyBigDecimal(), anyBigDecimal());
+    }
+
+    @Test
+    void shouldCloseOrderWithTakeProfitWhenThresholdBreached() {
+        BigDecimal takeProfitPrice = ENTRY_PRICE.multiply(TAKE_PROFIT_THRESHOLD.add(BigDecimal.valueOf(0.01)));
+
+        traderService.processOrderSLTP(1L, ENTRY_PRICE, takeProfitPrice);
+
+        verify(orderServiceApi).closeOrderWithState(1L, OrderState.CLOSED_TP);
+    }
+
+    @Test
+    void shouldCloseOrderWithStopLossWhenThresholdBreached() {
+        BigDecimal stopLossPrice = ENTRY_PRICE.multiply(STOP_LOSS_THRESHOLD.subtract(BigDecimal.valueOf(0.05)));
+
+        traderService.processOrderSLTP(2L, ENTRY_PRICE, stopLossPrice);
+
+        verify(orderServiceApi).closeOrderWithState(2L, OrderState.CLOSED_SL);
+    }
+
+    @Test
+    void shouldNotCloseOrderWhenThresholdsNotBreached() {
+        BigDecimal neutralPrice = ENTRY_PRICE;
+
+        traderService.processOrderSLTP(3L, ENTRY_PRICE, neutralPrice);
+
+        verify(orderServiceApi, never()).closeOrderWithState(anyLong(), any(OrderState.class));
+    }
+
+    private KlineEvent buildKlineEvent(BigDecimal closePrice) {
+        long now = Instant.now().toEpochMilli();
+        return KlineEvent.newBuilder()
+                .setEventType("kline")
+                .setEventTime(now)
+                .setSymbol(SYMBOL)
+                .setInterval("1m")
+                .setOpenTime(now - 60_000)
+                .setCloseTime(now)
+                .setOpen(closePrice)
+                .setHigh(closePrice)
+                .setLow(closePrice)
+                .setClose(closePrice)
+                .setVolume(BigDecimal.ONE)
+                .build();
+    }
+}


### PR DESCRIPTION
## Summary
- reinstate stop-loss and take-profit handling in TraderServiceImpl
- resume order inspection when executing trade signals and create groups when flat
- add unit tests covering signal-driven order creation, inversion handling, and SL/TP closures

## Testing
- mvn -f binance-trader-macd/pom.xml test *(fails: unable to download spring-boot-starter-parent 3.4.0-SNAPSHOT due to 403 from repo.spring.io)*

------
https://chatgpt.com/codex/tasks/task_e_68dc143748f88329a38ae1a3befb106f