### PR TITLE
Handle OCO order child persistence

### DIFF
--- a/binance-trader-macd/pom.xml
+++ b/binance-trader-macd/pom.xml
@@ -117,12 +117,17 @@
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
 		</dependency>
-		<dependency>
-			<groupId>org.springframework.kafka</groupId>
-			<artifactId>spring-kafka-test</artifactId>
-			<scope>test</scope>
-		</dependency>
-	</dependencies>
+                <dependency>
+                        <groupId>org.springframework.kafka</groupId>
+                        <artifactId>spring-kafka-test</artifactId>
+                        <scope>test</scope>
+                </dependency>
+                <dependency>
+                        <groupId>com.h2database</groupId>
+                        <artifactId>h2</artifactId>
+                        <scope>test</scope>
+                </dependency>
+        </dependencies>
 
 	<build>
 		<finalName>${name}</finalName>

--- a/binance-trader-macd/src/main/java/com/oyakov/binance_trader_macd/converter/BinanceOcoOrderReportToOrderConverter.java
+++ b/binance-trader-macd/src/main/java/com/oyakov/binance_trader_macd/converter/BinanceOcoOrderReportToOrderConverter.java
@@ -1,0 +1,73 @@
+package com.oyakov.binance_trader_macd.converter;
+
+import com.oyakov.binance_trader_macd.domain.OrderSide;
+import com.oyakov.binance_trader_macd.domain.OrderState;
+import com.oyakov.binance_trader_macd.domain.OrderType;
+import com.oyakov.binance_trader_macd.domain.TimeInForce;
+import com.oyakov.binance_trader_macd.model.order.binance.storage.OrderItem;
+import com.oyakov.binance_trader_macd.rest.dto.BinanceOcoOrderResponse;
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.stereotype.Component;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.util.Optional;
+
+@Component
+public class BinanceOcoOrderReportToOrderConverter implements Converter<BinanceOcoOrderResponse.OrderReport, OrderItem> {
+
+    private static final String EMPTY_JSON_ARRAY = "[]";
+
+    @Override
+    public OrderItem convert(BinanceOcoOrderResponse.OrderReport source) {
+        if (source == null) {
+            return null;
+        }
+
+        Long transactTime = Optional.ofNullable(source.getTransactTime()).orElse(0L);
+        Long workingTime = Optional.ofNullable(source.getWorkingTime()).orElse(transactTime);
+
+        return OrderItem.builder()
+                .symbol(Optional.ofNullable(source.getSymbol()).orElse(""))
+                .orderId(source.getOrderId())
+                .orderListId(Optional.ofNullable(source.getOrderListId()).map(Math::toIntExact).orElse(0))
+                .clientOrderId(Optional.ofNullable(source.getClientOrderId()).orElse(""))
+                .transactTime(transactTime)
+                .displayTransactTime(toLocalDateTime(transactTime))
+                .price(defaultBigDecimal(source.getPrice()))
+                .origQty(defaultBigDecimal(source.getOrigQty()))
+                .executedQty(defaultBigDecimal(source.getExecutedQty()))
+                .cummulativeQuoteQty(defaultBigDecimal(source.getCummulativeQuoteQty()))
+                .status(resolveOrderState(source.getStatus()))
+                .timeInForce(Optional.ofNullable(source.getTimeInForce()).orElse(TimeInForce.GTC.name()))
+                .type(resolveOrderType(source.getType()))
+                .side(resolveOrderSide(source.getSide()))
+                .workingTime(workingTime)
+                .displayWorkingTime(toLocalDateTime(workingTime))
+                .selfTradePreventionMode(Optional.ofNullable(source.getSelfTradePreventionMode()).orElse("NONE"))
+                .fills(EMPTY_JSON_ARRAY)
+                .build();
+    }
+
+    private static LocalDateTime toLocalDateTime(Long epochMillis) {
+        return Instant.ofEpochMilli(epochMillis).atZone(ZoneOffset.UTC).toLocalDateTime();
+    }
+
+    private static BigDecimal defaultBigDecimal(BigDecimal value) {
+        return value != null ? value : BigDecimal.ZERO;
+    }
+
+    private static OrderState resolveOrderState(String status) {
+        return Optional.ofNullable(OrderState.ofBinanceState(status)).orElse(OrderState.NEW);
+    }
+
+    private static OrderType resolveOrderType(String type) {
+        return Optional.ofNullable(type).map(OrderType::valueOf).orElse(OrderType.LIMIT);
+    }
+
+    private static OrderSide resolveOrderSide(String side) {
+        return Optional.ofNullable(side).map(OrderSide::valueOf).orElse(OrderSide.BUY);
+    }
+}

--- a/binance-trader-macd/src/main/java/com/oyakov/binance_trader_macd/service/impl/OrderServiceImpl.java
+++ b/binance-trader-macd/src/main/java/com/oyakov/binance_trader_macd/service/impl/OrderServiceImpl.java
@@ -76,10 +76,11 @@ public class OrderServiceImpl implements OrderServiceApi {
             OrderItem ocoItem = conversionService.convert(oco, OrderItem.class);
             if (ocoItem != null) {
                 ocoItem.setParentOrderId(entryOrder.getOrderId());
+                ocoOrders.add(ocoItem);
                 log.debug("Linked OCO order {} created for parent {}", ocoItem.getOrderId(), entryOrder.getOrderId());
             }
         }
-        log.debug("OCO orders created: {}", entryOrder);
+        log.debug("OCO orders created for parent {}: {}", entryOrder.getOrderId(), ocoOrders);
         return ocoOrders;
     }
 

--- a/binance-trader-macd/src/test/java/com/oyakov/binance_trader_macd/repository/jpa/OrderPostgresRepositoryTest.java
+++ b/binance-trader-macd/src/test/java/com/oyakov/binance_trader_macd/repository/jpa/OrderPostgresRepositoryTest.java
@@ -1,0 +1,91 @@
+package com.oyakov.binance_trader_macd.repository.jpa;
+
+import com.oyakov.binance_trader_macd.converter.BinanceOcoOrderReportToOrderConverter;
+import com.oyakov.binance_trader_macd.domain.OrderSide;
+import com.oyakov.binance_trader_macd.domain.OrderState;
+import com.oyakov.binance_trader_macd.domain.OrderType;
+import com.oyakov.binance_trader_macd.domain.TimeInForce;
+import com.oyakov.binance_trader_macd.model.order.binance.storage.OrderItem;
+import com.oyakov.binance_trader_macd.rest.dto.BinanceOcoOrderResponse;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.test.context.TestPropertySource;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+@TestPropertySource(properties = {
+        "spring.jpa.hibernate.ddl-auto=create-drop",
+        "spring.flyway.enabled=false"
+})
+class OrderPostgresRepositoryTest {
+
+    @Autowired
+    private OrderPostgresRepository orderRepository;
+
+    private final BinanceOcoOrderReportToOrderConverter converter = new BinanceOcoOrderReportToOrderConverter();
+
+    @Test
+    void shouldPersistOcoChildWithParentOrderId() {
+        OrderItem parentOrder = orderRepository.save(buildParentOrder(321L, 7));
+
+        BinanceOcoOrderResponse.OrderReport report = new BinanceOcoOrderResponse.OrderReport();
+        report.setSymbol("BTCUSDT");
+        report.setOrderId(654L);
+        report.setOrderListId(8L);
+        report.setClientOrderId("child-client-654");
+        report.setTransactTime(1_700_000_500_000L);
+        report.setPrice(new BigDecimal("24950.00"));
+        report.setOrigQty(new BigDecimal("0.010"));
+        report.setExecutedQty(BigDecimal.ZERO);
+        report.setCummulativeQuoteQty(BigDecimal.ZERO);
+        report.setStatus("ACTIVE");
+        report.setTimeInForce("GTC");
+        report.setType("STOP_LOSS_LIMIT");
+        report.setSide("SELL");
+        report.setWorkingTime(1_700_000_500_000L);
+        report.setSelfTradePreventionMode("NONE");
+
+        OrderItem childOrder = converter.convert(report);
+        assertThat(childOrder).isNotNull();
+        childOrder.setParentOrderId(parentOrder.getOrderId());
+
+        OrderItem savedChild = orderRepository.save(childOrder);
+        OrderItem persistedChild = orderRepository.findById(savedChild.getId()).orElseThrow();
+
+        assertThat(persistedChild.getParentOrderId()).isEqualTo(parentOrder.getOrderId());
+        assertThat(persistedChild.getOrderListId()).isEqualTo(8);
+    }
+
+    private static OrderItem buildParentOrder(Long orderId, int orderListId) {
+        long baseTime = 1_700_000_000_000L;
+        LocalDateTime displayTime = Instant.ofEpochMilli(baseTime).atZone(ZoneOffset.UTC).toLocalDateTime();
+
+        return OrderItem.builder()
+                .symbol("BTCUSDT")
+                .orderId(orderId)
+                .orderListId(orderListId)
+                .clientOrderId("parent-client-" + orderId)
+                .transactTime(baseTime)
+                .displayTransactTime(displayTime)
+                .price(new BigDecimal("25000.00"))
+                .origQty(new BigDecimal("0.010"))
+                .executedQty(BigDecimal.ZERO)
+                .cummulativeQuoteQty(BigDecimal.ZERO)
+                .status(OrderState.ACTIVE)
+                .timeInForce(TimeInForce.GTC.name())
+                .type(OrderType.LIMIT)
+                .side(OrderSide.BUY)
+                .workingTime(baseTime)
+                .displayWorkingTime(displayTime)
+                .selfTradePreventionMode("NONE")
+                .fills("[]")
+                .build();
+    }
+}


### PR DESCRIPTION
## Summary
- convert Binance OCO order reports into persistent OrderItem entities
- append converted OCO children to the collection returned from the order service and link them to their parent order
- add a repository test to verify OCO child orders persist with the correct parent reference

## Testing
- `mvn test` *(fails: Non-resolvable parent POM because spring-boot-starter-parent 3.4.0-SNAPSHOT cannot be downloaded without credentials)*

------
https://chatgpt.com/codex/tasks/task_e_68dc143bf8b883298975f06b47d47cca