### PR TITLE
Remove Spring milestone repositories from Java modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ All microservices are connected via **Kafka** as the event bus. Each service lis
 - **Python 3.x** (for the Telegram bot).
 - **Maven** for building Java microservices.
 
+> **Maven repositories:** Java modules now resolve dependencies exclusively from Maven Central plus the Confluent repository used for Kafka serializers. Milestone and snapshot repositories from Spring have been removed, so ensure any new dependencies are available from these release repositories before adding them.
+
 ### Docker Setup
 
 You can use the `docker-compose.yml` file to start all the services with the required dependencies (e.g., Kafka, Zookeeper, Elasticsearch).

--- a/binance-data-collection/pom.xml
+++ b/binance-data-collection/pom.xml
@@ -143,45 +143,11 @@
 			</plugin>
 		</plugins>
 	</build>
-	<repositories>
-		<repository>
-			<id>spring-milestones</id>
-			<name>Spring Milestones</name>
-			<url>https://repo.spring.io/milestone</url>
-			<snapshots>
-				<enabled>false</enabled>
-			</snapshots>
-		</repository>
-		<repository>
-			<id>spring-snapshots</id>
-			<name>Spring Snapshots</name>
-			<url>https://repo.spring.io/snapshot</url>
-			<releases>
-				<enabled>false</enabled>
-			</releases>
-		</repository>
-		<repository>
-			<id>confluent</id>
-			<url>https://packages.confluent.io/maven/</url>
-		</repository>
-	</repositories>
-	<pluginRepositories>
-		<pluginRepository>
-			<id>spring-milestones</id>
-			<name>Spring Milestones</name>
-			<url>https://repo.spring.io/milestone</url>
-			<snapshots>
-				<enabled>false</enabled>
-			</snapshots>
-		</pluginRepository>
-		<pluginRepository>
-			<id>spring-snapshots</id>
-			<name>Spring Snapshots</name>
-			<url>https://repo.spring.io/snapshot</url>
-			<releases>
-				<enabled>false</enabled>
-			</releases>
-		</pluginRepository>
-	</pluginRepositories>
+        <repositories>
+                <repository>
+                        <id>confluent</id>
+                        <url>https://packages.confluent.io/maven/</url>
+                </repository>
+        </repositories>
 
 </project>

--- a/binance-data-storage/pom.xml
+++ b/binance-data-storage/pom.xml
@@ -150,45 +150,11 @@
 			</plugin>
 		</plugins>
 	</build>
-	<repositories>
-		<repository>
-			<id>spring-milestones</id>
-			<name>Spring Milestones</name>
-			<url>https://repo.spring.io/milestone</url>
-			<snapshots>
-				<enabled>false</enabled>
-			</snapshots>
-		</repository>
-		<repository>
-			<id>spring-snapshots</id>
-			<name>Spring Snapshots</name>
-			<url>https://repo.spring.io/snapshot</url>
-			<releases>
-				<enabled>false</enabled>
-			</releases>
-		</repository>
-		<repository>
-			<id>confluent</id>
-			<url>https://packages.confluent.io/maven/</url>
-		</repository>
-	</repositories>
-	<pluginRepositories>
-		<pluginRepository>
-			<id>spring-milestones</id>
-			<name>Spring Milestones</name>
-			<url>https://repo.spring.io/milestone</url>
-			<snapshots>
-				<enabled>false</enabled>
-			</snapshots>
-		</pluginRepository>
-		<pluginRepository>
-			<id>spring-snapshots</id>
-			<name>Spring Snapshots</name>
-			<url>https://repo.spring.io/snapshot</url>
-			<releases>
-				<enabled>false</enabled>
-			</releases>
-		</pluginRepository>
-	</pluginRepositories>
+        <repositories>
+                <repository>
+                        <id>confluent</id>
+                        <url>https://packages.confluent.io/maven/</url>
+                </repository>
+        </repositories>
 
 </project>

--- a/binance-shared-model/pom.xml
+++ b/binance-shared-model/pom.xml
@@ -110,46 +110,12 @@
 			</plugin>
 		</plugins>
 	</build>
-	<repositories>
-		<repository>
-			<id>spring-milestones</id>
-			<name>Spring Milestones</name>
-			<url>https://repo.spring.io/milestone</url>
-			<snapshots>
-				<enabled>false</enabled>
-			</snapshots>
-		</repository>
-		<repository>
-			<id>spring-snapshots</id>
-			<name>Spring Snapshots</name>
-			<url>https://repo.spring.io/snapshot</url>
-			<releases>
-				<enabled>false</enabled>
-			</releases>
-		</repository>
-		<!-- Confluent Repository -->
-		<repository>
-			<id>confluent</id>
-			<url>https://packages.confluent.io/maven/</url>
-		</repository>
-	</repositories>
-	<pluginRepositories>
-		<pluginRepository>
-			<id>spring-milestones</id>
-			<name>Spring Milestones</name>
-			<url>https://repo.spring.io/milestone</url>
-			<snapshots>
-				<enabled>false</enabled>
-			</snapshots>
-		</pluginRepository>
-		<pluginRepository>
-			<id>spring-snapshots</id>
-			<name>Spring Snapshots</name>
-			<url>https://repo.spring.io/snapshot</url>
-			<releases>
-				<enabled>false</enabled>
-			</releases>
-		</pluginRepository>
-	</pluginRepositories>
+        <repositories>
+                <!-- Confluent Repository -->
+                <repository>
+                        <id>confluent</id>
+                        <url>https://packages.confluent.io/maven/</url>
+                </repository>
+        </repositories>
 
 </project>

--- a/binance-trader-grid/pom.xml
+++ b/binance-trader-grid/pom.xml
@@ -134,41 +134,4 @@
 			</plugin>
 		</plugins>
 	</build>
-	<repositories>
-		<repository>
-			<id>spring-milestones</id>
-			<name>Spring Milestones</name>
-			<url>https://repo.spring.io/milestone</url>
-			<snapshots>
-				<enabled>false</enabled>
-			</snapshots>
-		</repository>
-		<repository>
-			<id>spring-snapshots</id>
-			<name>Spring Snapshots</name>
-			<url>https://repo.spring.io/snapshot</url>
-			<releases>
-				<enabled>false</enabled>
-			</releases>
-		</repository>
-	</repositories>
-	<pluginRepositories>
-		<pluginRepository>
-			<id>spring-milestones</id>
-			<name>Spring Milestones</name>
-			<url>https://repo.spring.io/milestone</url>
-			<snapshots>
-				<enabled>false</enabled>
-			</snapshots>
-		</pluginRepository>
-		<pluginRepository>
-			<id>spring-snapshots</id>
-			<name>Spring Snapshots</name>
-			<url>https://repo.spring.io/snapshot</url>
-			<releases>
-				<enabled>false</enabled>
-			</releases>
-		</pluginRepository>
-	</pluginRepositories>
-
 </project>

--- a/binance-trader-macd/pom.xml
+++ b/binance-trader-macd/pom.xml
@@ -172,45 +172,11 @@
 			</plugin>
 		</plugins>
 	</build>
-	<repositories>
-		<repository>
-			<id>spring-milestones</id>
-			<name>Spring Milestones</name>
-			<url>https://repo.spring.io/milestone</url>
-			<snapshots>
-				<enabled>false</enabled>
-			</snapshots>
-		</repository>
-		<repository>
-			<id>spring-snapshots</id>
-			<name>Spring Snapshots</name>
-			<url>https://repo.spring.io/snapshot</url>
-			<releases>
-				<enabled>false</enabled>
-			</releases>
-		</repository>
-		<repository>
-			<id>confluent</id>
-			<url>https://packages.confluent.io/maven/</url>
-		</repository>
-	</repositories>
-	<pluginRepositories>
-		<pluginRepository>
-			<id>spring-milestones</id>
-			<name>Spring Milestones</name>
-			<url>https://repo.spring.io/milestone</url>
-			<snapshots>
-				<enabled>false</enabled>
-			</snapshots>
-		</pluginRepository>
-		<pluginRepository>
-			<id>spring-snapshots</id>
-			<name>Spring Snapshots</name>
-			<url>https://repo.spring.io/snapshot</url>
-			<releases>
-				<enabled>false</enabled>
-			</releases>
-		</pluginRepository>
-	</pluginRepositories>
+        <repositories>
+                <repository>
+                        <id>confluent</id>
+                        <url>https://packages.confluent.io/maven/</url>
+                </repository>
+        </repositories>
 
 </project>


### PR DESCRIPTION
## Summary
- remove Spring milestone and snapshot repositories from each Java module POM while retaining the Confluent repository
- document that builds now rely on Maven Central plus Confluent in the contributor README

## Testing
- ./binance-shared-model/mvnw -B -ntp dependency:go-offline
- ./binance-data-collection/mvnw -B -ntp dependency:go-offline
- ./binance-data-storage/mvnw -B -ntp dependency:go-offline
- ./binance-trader-grid/mvnw -B -ntp dependency:go-offline
- ./binance-trader-macd/mvnw -B -ntp dependency:go-offline

------
https://chatgpt.com/codex/tasks/task_e_68dc6a78b96883299177e1de57dfd203