### PR TITLE
Improve time analysis metrics and synthetic dataset stability

### DIFF
--- a/binance-trader-macd/src/main/java/com/oyakov/binance_trader_macd/domain/signal/MACDSignalAnalyzer.java
+++ b/binance-trader-macd/src/main/java/com/oyakov/binance_trader_macd/domain/signal/MACDSignalAnalyzer.java
@@ -72,7 +72,9 @@ public class MACDSignalAnalyzer implements SignalAnalyzer<KlineEvent> {
         int last = signalLine.size() - 1;
         BigDecimal prevDiff = macd.get(last - 1).subtract(signalLine.get(last - 1));
         BigDecimal currDiff = macd.get(last).subtract(signalLine.get(last));
-        log.info("Prev diff: {}, Curr diff: {}", prevDiff, currDiff);
+        if (log.isDebugEnabled()) {
+            log.debug("Prev diff: {}, Curr diff: {}", prevDiff, currDiff);
+        }
 
         if (prevDiff.compareTo(BigDecimal.ZERO) <= 0 && currDiff.compareTo(BigDecimal.ZERO) > 0) {
             return Optional.of(TradeSignal.BUY);


### PR DESCRIPTION
## Summary
- compute trade duration statistics using minute resolution and correct trades-per-day frequency in the metrics calculator
- add mean reversion and bounded hourly swings to the synthetic dataset generator for more realistic demo prices
- keep MACD diff logging quiet by guarding debug output

## Testing
- mvn -pl binance-trader-macd -Dtest=StandaloneBacktestDemo test

------
https://chatgpt.com/codex/tasks/task_e_68dd0ff20d6c8329b6c69418cf8049e4