### PR TITLE
Implement caching and standardized sampling windows for backtesting datasets

### DIFF
--- a/binance-data-collection/src/main/java/com/oyakov/binance_data_collection/sampler/BacktestDatasetFileWriter.java
+++ b/binance-data-collection/src/main/java/com/oyakov/binance_data_collection/sampler/BacktestDatasetFileWriter.java
@@ -11,6 +11,8 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
+import java.util.Locale;
+import java.util.regex.Pattern;
 
 @Component
 @Log4j2
@@ -19,6 +21,7 @@ public class BacktestDatasetFileWriter {
 
     private static final DateTimeFormatter FILE_TIME_FORMATTER =
             DateTimeFormatter.ofPattern("yyyyMMddHHmmss").withZone(ZoneOffset.UTC);
+    private static final Pattern SAFE_FILENAME_PATTERN = Pattern.compile("[^a-z0-9_-]+");
     private final ObjectMapper objectMapper;
 
     public Path writeDataset(BacktestDataset dataset, String outputDirectory) {
@@ -26,10 +29,8 @@ public class BacktestDatasetFileWriter {
             Path directory = Path.of(outputDirectory);
             Files.createDirectories(directory);
             String timestamp = FILE_TIME_FORMATTER.format(dataset.getCollectedAt());
-            String fileName = "%s_%s_%s.json".formatted(
-                    dataset.getSymbol().toLowerCase(),
-                    dataset.getInterval(),
-                    timestamp);
+            String datasetLabel = buildDatasetLabel(dataset);
+            String fileName = "%s_%s.json".formatted(datasetLabel, timestamp);
             Path file = directory.resolve(fileName);
             objectMapper.writerWithDefaultPrettyPrinter().writeValue(file.toFile(), dataset);
             log.info("Saved dataset {} with {} klines to {}", dataset.getName(), dataset.getKlines().size(), file);
@@ -37,5 +38,13 @@ public class BacktestDatasetFileWriter {
         } catch (IOException e) {
             throw new IllegalStateException("Failed to write dataset " + dataset.getName(), e);
         }
+    }
+
+    private String buildDatasetLabel(BacktestDataset dataset) {
+        String baseName = dataset.getName() != null && !dataset.getName().isBlank()
+                ? dataset.getName()
+                : "%s_%s".formatted(dataset.getSymbol(), dataset.getInterval());
+        String lower = baseName.toLowerCase(Locale.ROOT).replace(' ', '-');
+        return SAFE_FILENAME_PATTERN.matcher(lower).replaceAll("-");
     }
 }

--- a/binance-data-collection/src/main/java/com/oyakov/binance_data_collection/sampler/HistoricalKlineCache.java
+++ b/binance-data-collection/src/main/java/com/oyakov/binance_data_collection/sampler/HistoricalKlineCache.java
@@ -1,0 +1,51 @@
+package com.oyakov.binance_data_collection.sampler;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.oyakov.binance_shared_model.backtest.BacktestDataset;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Optional;
+
+@Component
+@Log4j2
+@RequiredArgsConstructor
+public class HistoricalKlineCache {
+
+    private final ObjectMapper objectMapper;
+
+    public Optional<BacktestDataset> loadDataset(String cacheDirectory, String cacheKey) {
+        Path cachePath = resolvePath(cacheDirectory, cacheKey);
+        if (!Files.exists(cachePath)) {
+            return Optional.empty();
+        }
+        try {
+            BacktestDataset dataset = objectMapper.readValue(cachePath.toFile(), BacktestDataset.class);
+            log.info("Loaded cached dataset {} from {}", cacheKey, cachePath);
+            return Optional.of(dataset);
+        } catch (IOException e) {
+            log.warn("Failed to read cached dataset from {}. Ignoring cache entry.", cachePath, e);
+            return Optional.empty();
+        }
+    }
+
+    public void saveDataset(BacktestDataset dataset, String cacheDirectory, String cacheKey) {
+        Path cachePath = resolvePath(cacheDirectory, cacheKey);
+        try {
+            Files.createDirectories(cachePath.getParent());
+            objectMapper.writerWithDefaultPrettyPrinter().writeValue(cachePath.toFile(), dataset);
+            log.info("Cached dataset {} with {} klines at {}", cacheKey, dataset.getKlines().size(), cachePath);
+        } catch (IOException e) {
+            log.warn("Failed to write cached dataset {} to {}", cacheKey, cachePath, e);
+        }
+    }
+
+    private Path resolvePath(String cacheDirectory, String cacheKey) {
+        String safeKey = cacheKey.replaceAll("[^a-zA-Z0-9_-]", "-");
+        return Path.of(cacheDirectory).resolve(safeKey + ".json");
+    }
+}

--- a/binance-data-collection/src/main/java/com/oyakov/binance_data_collection/sampler/HistoricalKlineSampler.java
+++ b/binance-data-collection/src/main/java/com/oyakov/binance_data_collection/sampler/HistoricalKlineSampler.java
@@ -9,43 +9,155 @@ import org.springframework.stereotype.Component;
 
 import java.nio.file.Path;
 import java.time.Instant;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 @Component
 @Log4j2
 @RequiredArgsConstructor
 public class HistoricalKlineSampler {
 
+    private static final DateTimeFormatter CACHE_DAY_FORMATTER =
+            DateTimeFormatter.ofPattern("yyyyMMdd").withZone(ZoneOffset.UTC);
+
     private final BinanceRestKlineClient klineClient;
     private final HistoricalSamplerProperties properties;
     private final BacktestDatasetFileWriter datasetWriter;
+    private final HistoricalKlineCache klineCache;
 
     public List<Path> collect() {
         Instant collectedAt = Instant.now();
+        Instant defaultEndInstant = resolveEndInstant(collectedAt);
+        boolean useStandardRanges = shouldUseStandardRanges();
         List<Path> savedFiles = new ArrayList<>();
         for (String symbol : properties.getSymbols()) {
             for (String interval : properties.getIntervals()) {
-                List<KlineEvent> klines = klineClient.fetchHistoricalKlines(
-                        symbol,
-                        interval,
-                        properties.getLimit(),
-                        properties.getStartTime(),
-                        properties.getEndTime());
-                if (klines.isEmpty()) {
-                    log.warn("No klines received for {} {}", symbol, interval);
-                    continue;
+                if (useStandardRanges) {
+                    for (Integer days : properties.getDayRanges()) {
+                        Path saved = collectForDayRange(symbol, interval, days, collectedAt, defaultEndInstant);
+                        if (saved != null) {
+                            savedFiles.add(saved);
+                        }
+                    }
+                } else {
+                    Path saved = collectWithCustomWindow(symbol, interval, collectedAt);
+                    if (saved != null) {
+                        savedFiles.add(saved);
+                    }
                 }
-                BacktestDataset dataset = BacktestDataset.builder()
-                        .name(symbol + "_" + interval)
-                        .symbol(symbol.toUpperCase())
-                        .interval(interval)
-                        .collectedAt(collectedAt)
-                        .klines(klines)
-                        .build();
-                savedFiles.add(datasetWriter.writeDataset(dataset, properties.getOutputDirectory()));
             }
         }
         return savedFiles;
+    }
+
+    private Path collectForDayRange(String symbol,
+                                    String interval,
+                                    Integer days,
+                                    Instant collectedAt,
+                                    Instant endInstant) {
+        if (days == null || days <= 0) {
+            log.warn("Skipping invalid day range {} for {} {}", days, symbol, interval);
+            return null;
+        }
+        Instant startInstant = endInstant.minus(days, ChronoUnit.DAYS);
+        String cacheKey = buildDayRangeCacheKey(symbol, interval, days, endInstant);
+        List<KlineEvent> klines = resolveKlines(symbol, interval, null,
+                startInstant.toEpochMilli(), endInstant.toEpochMilli(), collectedAt, cacheKey);
+        if (klines.isEmpty()) {
+            log.warn("No klines received for {} {} over {} days", symbol, interval, days);
+            return null;
+        }
+        BacktestDataset dataset = BacktestDataset.builder()
+                .name(symbol.toUpperCase() + "_" + interval + "_" + days + "d")
+                .symbol(symbol.toUpperCase())
+                .interval(interval)
+                .collectedAt(collectedAt)
+                .klines(klines)
+                .build();
+        return datasetWriter.writeDataset(dataset, properties.getOutputDirectory());
+    }
+
+    private Path collectWithCustomWindow(String symbol, String interval, Instant collectedAt) {
+        String cacheKey = buildCustomWindowCacheKey(symbol, interval);
+        List<KlineEvent> klines = resolveKlines(symbol, interval,
+                properties.getLimit(), properties.getStartTime(), properties.getEndTime(), collectedAt, cacheKey);
+        if (klines.isEmpty()) {
+            log.warn("No klines received for {} {}", symbol, interval);
+            return null;
+        }
+        BacktestDataset dataset = BacktestDataset.builder()
+                .name(symbol.toUpperCase() + "_" + interval)
+                .symbol(symbol.toUpperCase())
+                .interval(interval)
+                .collectedAt(collectedAt)
+                .klines(klines)
+                .build();
+        return datasetWriter.writeDataset(dataset, properties.getOutputDirectory());
+    }
+
+    private List<KlineEvent> resolveKlines(String symbol,
+                                          String interval,
+                                          Integer limit,
+                                          Long startTime,
+                                          Long endTime,
+                                          Instant collectedAt,
+                                          String cacheKey) {
+        if (properties.isCacheEnabled()) {
+            Optional<BacktestDataset> cached = klineCache.loadDataset(properties.getCacheDirectory(), cacheKey);
+            if (cached.isPresent()) {
+                return new ArrayList<>(cached.get().getKlines());
+            }
+        }
+
+        List<KlineEvent> klines = klineClient.fetchHistoricalKlines(symbol, interval, limit, startTime, endTime);
+        if (!klines.isEmpty() && properties.isCacheEnabled()) {
+            BacktestDataset cacheDataset = BacktestDataset.builder()
+                    .name(cacheKey)
+                    .symbol(symbol.toUpperCase())
+                    .interval(interval)
+                    .collectedAt(collectedAt)
+                    .klines(List.copyOf(klines))
+                    .build();
+            klineCache.saveDataset(cacheDataset, properties.getCacheDirectory(), cacheKey);
+        }
+        return klines;
+    }
+
+    private Instant resolveEndInstant(Instant fallback) {
+        if (properties.getEndTime() != null) {
+            return Instant.ofEpochMilli(properties.getEndTime());
+        }
+        return fallback;
+    }
+
+    private boolean shouldUseStandardRanges() {
+        return properties.getDayRanges() != null
+                && !properties.getDayRanges().isEmpty()
+                && properties.getStartTime() == null
+                && properties.getEndTime() == null;
+    }
+
+    private String buildDayRangeCacheKey(String symbol, String interval, int days, Instant endInstant) {
+        String dayLabel = CACHE_DAY_FORMATTER.format(endInstant);
+        return "%s_%s_%dd_%s".formatted(symbol.toLowerCase(), interval, days, dayLabel);
+    }
+
+    private String buildCustomWindowCacheKey(String symbol, String interval) {
+        StringBuilder descriptor = new StringBuilder();
+        if (properties.getStartTime() != null || properties.getEndTime() != null) {
+            descriptor.append("window_");
+            descriptor.append(properties.getStartTime() != null ? properties.getStartTime() : "na");
+            descriptor.append("_");
+            descriptor.append(properties.getEndTime() != null ? properties.getEndTime() : "na");
+        } else if (properties.getLimit() != null) {
+            descriptor.append("limit_").append(properties.getLimit());
+        } else {
+            descriptor.append("open-window");
+        }
+        return "%s_%s_%s".formatted(symbol.toLowerCase(), interval, descriptor);
     }
 }

--- a/binance-data-collection/src/main/java/com/oyakov/binance_data_collection/sampler/HistoricalSamplerProperties.java
+++ b/binance-data-collection/src/main/java/com/oyakov/binance_data_collection/sampler/HistoricalSamplerProperties.java
@@ -5,6 +5,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.stereotype.Component;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 @Data
@@ -13,10 +14,30 @@ import java.util.List;
 public class HistoricalSamplerProperties {
 
     private boolean enabled = false;
-    private List<String> symbols = new ArrayList<>();
-    private List<String> intervals = new ArrayList<>();
+    private List<String> symbols = new ArrayList<>(Arrays.asList(
+            "BTCUSDT",
+            "ETHUSDT",
+            "ADAUSDT",
+            "BNBUSDT",
+            "SOLUSDT",
+            "XRPUSDT",
+            "MATICUSDT",
+            "LTCUSDT"
+    ));
+    private List<String> intervals = new ArrayList<>(Arrays.asList(
+            "15m",
+            "1h",
+            "2h",
+            "4h",
+            "6h",
+            "1d",
+            "1w"
+    ));
     private Integer limit = 500;
     private Long startTime;
     private Long endTime;
     private String outputDirectory = "backtest-datasets";
+    private List<Integer> dayRanges = new ArrayList<>(Arrays.asList(90, 180, 365, 720));
+    private boolean cacheEnabled = true;
+    private String cacheDirectory = "backtest-cache";
 }


### PR DESCRIPTION
## Summary
- expand the sampler defaults to cover the optimization plan's target symbols, intervals, and standardized day ranges
- add a reusable historical kline cache and integrate it into the sampler to avoid redundant REST calls
- enrich dataset file naming to include strategy scope metadata for downstream reporting

## Testing
- `mvn -B -pl binance-data-collection test` *(fails: missing com.oyakov:binance-shared-model:0.1.1-SNAPSHOT artifact in remote repositories)*

------
https://chatgpt.com/codex/tasks/task_e_68dd2f4b6d748329a28bd2950294468d