### PR TITLE
Fix test imports for signals service modules

### DIFF
--- a/telegram-frontend-python/tests/__init__.py
+++ b/telegram-frontend-python/tests/__init__.py
@@ -1,1 +1,11 @@
 
+"""Test package initialization for the telegram frontend project."""
+
+from pathlib import Path
+import sys
+
+# Ensure the application source directory is importable when running the test suite.
+SRC_PATH = Path(__file__).resolve().parents[1] / 'src'
+if SRC_PATH.exists():
+    sys.path.insert(0, str(SRC_PATH))
+

--- a/telegram-frontend-python/tests/service/crypto/signals/signals_service_comprehensive_test.py
+++ b/telegram-frontend-python/tests/service/crypto/signals/signals_service_comprehensive_test.py
@@ -7,17 +7,23 @@ including RSI, MACD, and other technical indicators.
 
 import pytest
 import sys
-import os
+from pathlib import Path
 import pandas as pd
 import numpy as np
 import asyncio
 from unittest.mock import Mock, patch
 
-# Add src to path for imports
-sys.path.append(os.path.join(os.path.dirname(__file__), '..', '..', '..', '..', 'src'))
+# Add src to path for imports when running the test suite directly
+SRC_PATH = Path(__file__).resolve().parents[4] / 'src'
+if SRC_PATH.exists():
+    sys.path.insert(0, str(SRC_PATH))
 
-from service.crypto.signals.signals_service import SignalsService
-from tests.test_utils import TestDataFactory, MockFactory, assert_approximately_equal
+from tests.test_utils import (
+    TestDataFactory,
+    MockFactory,
+    assert_approximately_equal,
+    SignalsService,
+)
 
 
 class TestSignalsServiceComprehensive:

--- a/telegram-frontend-python/tests/service/crypto/signals/signals_service_test.py
+++ b/telegram-frontend-python/tests/service/crypto/signals/signals_service_test.py
@@ -1,13 +1,17 @@
 import unittest
 from unittest.async_case import IsolatedAsyncioTestCase
 
-from pandas import Series, DataFrame
+from pandas import Series
 
 import sys
-import os
-sys.path.append(os.path.join(os.path.dirname(__file__), '..', '..', '..', 'src'))
+from pathlib import Path
 
-from service.crypto.signals.signals_service import SignalsService
+# Ensure the src directory is available on the import path when tests are executed
+SRC_PATH = Path(__file__).resolve().parents[4] / 'src'
+if SRC_PATH.exists():
+    sys.path.insert(0, str(SRC_PATH))
+
+from tests.test_utils import SignalsService
 
 
 class MyTestCase(IsolatedAsyncioTestCase):


### PR DESCRIPTION
## Summary
- ensure the telegram frontend tests add the src directory to sys.path before discovery
- add dynamic module loader utilities so signals service tests can import the production code without namespace clashes
- update signals service tests to consume the shared helper and avoid direct package imports that previously failed

## Testing
- python -m unittest discover -s tests -p '*_test.py'


------
https://chatgpt.com/codex/tasks/task_e_68dd44d40d808329990803d11f24cb73