### PR TITLE
Handle missing python-dotenv gracefully

### DIFF
--- a/telegram-frontend-python/src/oam/environment.py
+++ b/telegram-frontend-python/src/oam/environment.py
@@ -1,8 +1,22 @@
 import os
+import importlib.util
+import importlib
 
-from dotenv import load_dotenv
 
-load_dotenv()
+def _load_dotenv() -> None:
+    """Load environment variables from a ``.env`` file when python-dotenv is available."""
+
+    dotenv_spec = importlib.util.find_spec("dotenv")
+    if dotenv_spec is None:
+        return
+
+    module = importlib.import_module("dotenv")
+    load = getattr(module, "load_dotenv", None)
+    if callable(load):
+        load()
+
+
+_load_dotenv()
 
 ############################################################################
 # Access the variables


### PR DESCRIPTION
## Summary
- avoid unconditional python-dotenv import in the environment module by checking for the package before loading

## Testing
- python -m unittest discover -s tests -p '*_test.py'


------
https://chatgpt.com/codex/tasks/task_e_68dd503fd7188329847742cf0de83724